### PR TITLE
Add `plugin:hyprtasking:swap_mouse_actions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Then use `hyprctl plugin load` to load the absolute path to the `.so` file.
 - Window management:
     - **Left click** to drag and drop windows around
 
+> [!NOTE]
+> If either `input:left_handed` or `plugin:hyprtasking:swap_mouse_action` is set to `true`, then right and left clicks are swapped
+
 ## Configuration
 
 Example below:
@@ -131,6 +134,7 @@ plugin {
         gap_size = 20
         bg_color = 0xff26233a
         border_size = 4
+        swap_mouse_actions = false
         exit_on_hovered = false
 
         gestures {
@@ -193,6 +197,7 @@ All options should are prefixed with `plugin:hyprtasking:`.
 | `bg_color` | `Hyprlang::INT` | The color of the background of the overlay | `0x000000FF` |
 | `gap_size` | `Hyprlang::FLOAT` | The width in logical pixels of the gaps between workspaces | `8.f` |
 | `border_size` | `Hyprlang::FLOAT` | The width in logical pixels of the borders around workspaces | `4.f` |
+| `swap_mouse_actions` | `Hyprlang::INT` | When enabled makes left click exit overview and right click drag windows | `false` |
 | `exit_on_hovered` | `Hyprlang::INT` | If true, hiding the workspace will exit to the hovered workspace instead of the active workspace. | `false` |
 | `gestures:enabled` | `Hyprlang::INT` | Whether or not to enable gestures | `true` |
 | `gestures:move_fingers` | `Hyprlang::INT` | The number of fingers to use for the "move" gesture | `3` |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,11 +180,20 @@ static void on_mouse_button(void* thisptr, SCallbackInfo& info, std::any args) {
     const auto e = std::any_cast<IPointer::SButtonEvent>(args);
     const bool pressed = e.state == WL_POINTER_BUTTON_STATE_PRESSED;
 
-    if (pressed && e.button == BTN_LEFT) {
+    unsigned int BUTTON_DRAG = BTN_LEFT;
+    unsigned int BUTTON_EXIT = BTN_RIGHT;
+
+    const int swap_mouse = HTConfig::value<Hyprlang::INT>("swap_mouse_actions");
+    if (swap_mouse) {
+        BUTTON_DRAG = BTN_RIGHT;
+        BUTTON_EXIT = BTN_LEFT;
+    }
+
+    if (pressed && e.button == BUTTON_DRAG) {
         info.cancelled = ht_manager->start_window_drag();
-    } else if (!pressed && e.button == BTN_LEFT) {
+    } else if (!pressed && e.button == BUTTON_DRAG) {
         info.cancelled = ht_manager->end_window_drag();
-    } else if (pressed && e.button == BTN_RIGHT) {
+    } else if (pressed && e.button == BUTTON_EXIT) {
         info.cancelled = ht_manager->exit_to_workspace();
     }
 }
@@ -367,6 +376,7 @@ static void init_config() {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:layout", Hyprlang::STRING {"grid"});
 
     // general
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:swap_mouse_actions", Hyprlang::INT {0});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:bg_color", Hyprlang::INT {0x000000FF});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:gap_size", Hyprlang::FLOAT {8.f});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:border_size", Hyprlang::FLOAT {4.f});


### PR DESCRIPTION
This PR adds `plugin:hyprtasking:swap_mouse_actions`.

When this option is enabled and `input:left_handed` isn't, right click drags windows and left click exits overview

Fixes #67