### PR TITLE
Add `close_overview_on_reload`

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ plugin {
         bg_color = 0xff26233a
         border_size = 4
         exit_on_hovered = false
+        close_overview_on_reload = true
 
         gestures {
             enabled = true
@@ -194,6 +195,7 @@ All options should are prefixed with `plugin:hyprtasking:`.
 | `gap_size` | `Hyprlang::FLOAT` | The width in logical pixels of the gaps between workspaces | `8.f` |
 | `border_size` | `Hyprlang::FLOAT` | The width in logical pixels of the borders around workspaces | `4.f` |
 | `exit_on_hovered` | `Hyprlang::INT` | If true, hiding the workspace will exit to the hovered workspace instead of the active workspace. | `false` |
+| `close_overview_on_reload ` | `Hyprlang::INT` | Whether to close the overview if its type didn't type didn't change after hyprland config reload | `true` |
 | `gestures:enabled` | `Hyprlang::INT` | Whether or not to enable gestures | `true` |
 | `gestures:move_fingers` | `Hyprlang::INT` | The number of fingers to use for the "move" gesture | `3` |
 | `gestures:move_distance` | `Hyprlang::FLOAT` | How large of a swipe on the touchpad corresponds to the width of a workspace | `300.f` |

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,8 +283,12 @@ static void on_config_reloaded(void* thisptr, SCallbackInfo& info, std::any args
     for (PHTVIEW& view : ht_manager->views) {
         if (view == nullptr)
             continue;
-        view->hide(false);
-        view->change_layout(HTConfig::value<Hyprlang::STRING>("layout"));
+        const Hyprlang::STRING new_layout = HTConfig::value<Hyprlang::STRING>("layout");
+        if (HTConfig::value<Hyprlang::INT>("close_overview_on_reload") || view->layout->layout_name() != new_layout) {
+            Debug::log(LOG, "[Hyprtasking] Closing overview on config reload");
+            view->hide(false);
+            view->change_layout(new_layout);
+        }
     }
 }
 
@@ -371,6 +375,7 @@ static void init_config() {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:gap_size", Hyprlang::FLOAT {8.f});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:border_size", Hyprlang::FLOAT {4.f});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:exit_on_hovered", Hyprlang::INT {0});
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:close_overview_on_reload", Hyprlang::INT {1});
 
     // swipe
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:gestures:enabled", Hyprlang::INT {1});


### PR DESCRIPTION
This PR adds `plugin:hyprtasking:close_overview_on_reload` option to disable closing the overview every config reload (I find it annoying)