### PR TITLE
Add `linear:top` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ plugin {
         }
 
         linear {
+            top = false
             height = 400
             scroll_speed = 1.0
             blur = false
@@ -218,6 +219,7 @@ All options should are prefixed with `plugin:hyprtasking:`.
 | `grid:cols` | `Hyprlang::INT` | The number of columns to display on the grid overlay | `3` |
 | `grid:loop` | `Hyprlang::INT` | When enabled, moving right at the far right of the grid will wrap around to the leftmost workspace, etc. | `false` |
 | `grid:gaps_use_aspect_ratio` | `Hyprlang::INT` | When enabled, vertical gaps will be scaled to match the monitor's aspect ratio | `false` |
+| `linear:top` | `Hyprlang::INT` | Whether or not to position the overview on top of the screen | `false` |
 | `linear:blur` | `Hyprlang::INT` | Whether or not to blur the dimmed area | `false` |
 | `linear:height` | `Hyprlang::FLOAT` | The height of the linear overlay in logical pixels | `300.f` |
 | `linear:scroll_speed` | `Hyprlang::FLOAT` | Scroll speed modifier. Set negative to flip direction | `1.f` |

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -167,6 +167,13 @@ bool HTLayoutLinear::on_mouse_axis(double delta) {
     return true;
 }
 
+const float calculate_y(float size_y, float offset_value, float max_offset) {
+    const bool top = HTConfig::value<Hyprlang::FLOAT>("linear:top");
+    if (top)
+        return offset_value - max_offset;
+    return size_y - offset_value;
+}
+
 bool HTLayoutLinear::should_manage_mouse() {
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
@@ -176,7 +183,7 @@ bool HTLayoutLinear::should_manage_mouse() {
 
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
     CBox scaled_view_box = {
-        Vector2D {0.f, monitor->m_transformedSize.y - view_offset->value()},
+        Vector2D {0.f, calculate_y(monitor->m_transformedSize.y, view_offset->value(), HEIGHT)},
         {(float)monitor->m_transformedSize.x, (float)HEIGHT}
     };
 
@@ -253,7 +260,7 @@ CBox HTLayoutLinear::calculate_ws_box(int x, int y, HTViewStage stage) {
     const float ws_width = ws_height * monitor->m_transformedSize.x / monitor->m_transformedSize.y;
 
     const float ws_x = scroll_offset->value() + (x * (GAP_SIZE + ws_width) + GAP_SIZE);
-    const float ws_y = monitor->m_transformedSize.y - use_view_offset + GAP_SIZE;
+    const float ws_y = calculate_y(monitor->m_transformedSize.y, use_view_offset, HEIGHT) + GAP_SIZE;
     return CBox {ws_x, ws_y, ws_width, ws_height};
 }
 
@@ -365,7 +372,7 @@ void HTLayoutLinear::render() {
     rendering_standard_ws = false;
 
     CBox view_box = {
-        {0.f, monitor->m_transformedSize.y - view_offset->value()},
+        {0.f, calculate_y(monitor->m_transformedSize.y, view_offset->value(), HEIGHT)},
         {(float)monitor->m_transformedSize.x, (float)HEIGHT}
     };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -450,6 +450,7 @@ static void init_config() {
         "plugin:hyprtasking:linear:scroll_speed",
         Hyprlang::FLOAT {1.f}
     );
+    HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:linear:top", Hyprlang::INT {0});
 
     // Old config value, warning about updates
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:rows", Hyprlang::INT {-1});


### PR DESCRIPTION
Adds option for linear layout to position overview on top of the monitor. As requested in #51