### PR TITLE
Only recalculate the workspaces when needed

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -287,7 +287,7 @@ bool HTManager::swipe_end() {
             const float OPEN_DISTANCE = HTConfig::value<Hyprlang::FLOAT>("gestures:open_distance");
             const float swipe_perc = 1.0 - std::clamp(swipe_amt / OPEN_DISTANCE, 0.01f, 1.0f);
             if (swipe_perc >= 0.5) {
-                cursor_view->show();
+                cursor_view->show(false);
             } else {
                 cursor_view->hide(false);
             }

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -141,10 +141,6 @@ void HTLayoutGrid::on_show(CallbackFun on_complete) {
     if (monitor == nullptr)
         return;
 
-    // HACK: This is needed to recalculate the position of the current workspace,
-    // so we don't start animating from an inactive workspace
-    init_position();
-
     *scale = calculate_ws_box(0, 0, HT_VIEW_OPENED).w / monitor->m_transformedSize.x; // 1 / ROWS
     // Offset for the whole grid of workspaces
     *offset = {0, 0};

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -71,7 +71,7 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
     monitor->changeWorkspace(workspace);
 }
 
-void HTView::show() {
+void HTView::show(bool recalculate) {
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
         return;
@@ -83,6 +83,9 @@ void HTView::show() {
     closing = false;
     navigating = false;
 
+    if (recalculate) {
+        layout->init_position();
+    }
     layout->on_show();
 
     Cursor::overrideController->setOverride("left_ptr", Cursor::CURSOR_OVERRIDE_UNKNOWN);

--- a/src/overview.hpp
+++ b/src/overview.hpp
@@ -31,7 +31,7 @@ class HTView {
 
     PHLMONITOR get_monitor();
 
-    void show();
+    void show(bool recalculate = true);
     void hide(bool exit_on_mouse);
 
     void move_id(WORKSPACEID ws_id, bool move_window);


### PR DESCRIPTION
#102 broke overview animation with touchpad gestures because it always recalculated the layout on `show()`, this fixes the problem