### PR TITLE
fix: guard against uninitialized monitor size during connect

### DIFF
--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -215,14 +215,26 @@ void HTLayoutGrid::init_position() {
     if (monitor == nullptr)
         return;
 
+    if (monitor->m_activeWorkspace == nullptr)
+        return;
+
     build_overview_layout(HT_VIEW_CLOSED);
-    offset->setValueAndWarp(-overview_layout[monitor->m_activeWorkspace->m_id].box.pos());
+
+    const auto it = overview_layout.find(monitor->m_activeWorkspace->m_id);
+    if (it == overview_layout.end() || it->second.box.empty())
+        return;
+
+    offset->setValueAndWarp(-it->second.box.pos());
     scale->setValueAndWarp(1.f);
 }
 
 CBox HTLayoutGrid::calculate_ws_box(int x, int y, HTViewStage stage) {
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
+        return {};
+
+    // Monitor may not have its final size yet during connect/reconnect
+    if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
         return {};
 
     const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
@@ -238,7 +250,7 @@ CBox HTLayoutGrid::calculate_ws_box(int x, int y, HTViewStage stage) {
 
     if (GAP_SIZE > std::min(monitor->m_transformedSize.x, monitor->m_transformedSize.y)
         || GAP_SIZE < 0)
-        fail_exit("Gap size {} induces invalid render dimensions", GAP_SIZE);
+        return {};
 
     double render_x = (monitor->m_transformedSize.x - gaps.x * (COLS + 1)) / COLS;
     double render_y = (monitor->m_transformedSize.y - gaps.y * (ROWS + 1)) / ROWS;

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -242,14 +242,18 @@ CBox HTLayoutLinear::calculate_ws_box(int x, int y, HTViewStage stage) {
     if (monitor == nullptr)
         return {};
 
+    // Monitor may not have its final size yet during connect/reconnect
+    if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
+        return {};
+
     const float HEIGHT = HTConfig::value<Hyprlang::FLOAT>("linear:height") * monitor->m_scale;
     const float GAP_SIZE = HTConfig::value<Hyprlang::FLOAT>("gap_size") * monitor->m_scale;
 
     if (HEIGHT < 0 || HEIGHT > monitor->m_transformedSize.y)
-        fail_exit("Linear layout height {} is taller than monitor size", HEIGHT);
+        return {};
 
     if (GAP_SIZE < 0 || GAP_SIZE > HEIGHT / 2.f)
-        fail_exit("Invalid gap_size {} for linear layout", GAP_SIZE);
+        return {};
 
     float use_view_offset = view_offset->value();
     if (stage == HT_VIEW_CLOSED)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,6 +253,10 @@ static void register_monitors() {
     if (ht_manager == nullptr)
         return;
     for (const PHLMONITOR& monitor : g_pCompositor->m_monitors) {
+        // Skip monitors that haven't finished initializing
+        if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
+            continue;
+
         const PHTVIEW view = ht_manager->get_view_from_monitor(monitor);
         if (view != nullptr) {
             if (!view->active)


### PR DESCRIPTION
## Summary

Fixes SIGABRT crashes during monitor connect/reconnect events (e.g., suspend/resume, VT switch, DRM session reactivation).

**Root cause:** When a monitor connects, `m_transformedSize` may be `{0, 0}` before initialization completes. The `monitor.added` signal fires `register_monitors` → `init_position` → `calculate_ws_box`, where gap_size validation (`GAP_SIZE > min(width, height)`) fails against the zero-sized monitor, triggering `fail_exit()` → `std::terminate` → SIGABRT.

**Changes:**
- `calculate_ws_box` (grid + linear): return empty `CBox` when monitor size is zero or gap/height validation fails, instead of calling `fail_exit()`
- `init_position` (grid): guard against null `m_activeWorkspace` and missing overview layout entries
- `register_monitors`: skip monitors with zero `m_transformedSize`

**Crash backtrace** (from `~/.cache/hyprland/hyprlandCrashReport*.txt`):
```
#11 | hyprtasking.so fail_exit<float>()
#12 | hyprtasking.so HTLayoutGrid::calculate_ws_box()
#13 | hyprtasking.so HTLayoutGrid::build_overview_layout()
#14 | hyprtasking.so HTLayoutGrid::init_position()
#15 | hyprtasking.so register_monitors()
...
#26 | Hyprland CMonitor::onConnect(bool)
#31 | libaquamarine.so SDRMConnector::connect()
```

Log context shows `ERR from aquamarine: drm: Session inactive` with progressively smaller buffer allocations before the crash.

Tested on Hyprland v0.54.3, Intel Arc 130V + NVIDIA RTX 4050 (Lunar Lake).

Relates to #93.

## Test plan

- [ ] Suspend/resume laptop with hyprtasking loaded — should not crash
- [ ] Hot-plug external monitor — should register view after monitor initializes
- [ ] VT switch (Ctrl+Alt+F2 → Ctrl+Alt+F1) — should survive session reactivation
- [ ] Normal overview toggle — should continue working as before