### PR TITLE
Respect monitor-local workspaces in overview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ libhyprtasking.so
 build
 
 result
+
+graphify-out
+
+.opencode
+
+AGENTS.md

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -2,36 +2,44 @@
 
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <hyprutils/math/Vector2D.hpp>
+#include <string>
+#include <unordered_map>
 
 #include "globals.hpp"
 
 namespace HTConfig {
 
-template<typename T>
-concept ptr_type = std::same_as<T, Hyprlang::STRING>;
-
-template<ptr_type T>
-inline T value(std::string config) {
-    static std::unordered_map<std::string, T const*> cache;
+inline Hyprlang::INT value(std::string config) {
+    static std::unordered_map<std::string, Hyprlang::INT* const*> cache;
 
     if (!cache.count(config))
-        cache[config] =
-            (T const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprtasking:" + config)
-                ->getDataStaticPtr();
-    return *cache[config];
+        cache[config] = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(
+                            PHANDLE,
+                            "plugin:hyprtasking:" + config
+                        )->getDataStaticPtr();
+    return **cache[config];
 }
 
-template<typename T>
-inline T value(std::string config)
-    requires(!ptr_type<T>)
-{
-    static std::unordered_map<std::string, T* const*> cache;
+inline Hyprlang::FLOAT value_float(std::string config) {
+    static std::unordered_map<std::string, Hyprlang::FLOAT* const*> cache;
 
     if (!cache.count(config))
-        cache[config] =
-            (T* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:hyprtasking:" + config)
-                ->getDataStaticPtr();
+        cache[config] = (Hyprlang::FLOAT* const*)HyprlandAPI::getConfigValue(
+                            PHANDLE,
+                            "plugin:hyprtasking:" + config
+                        )->getDataStaticPtr();
     return **cache[config];
+}
+
+inline Hyprlang::STRING value_string(std::string config) {
+    static std::unordered_map<std::string, Hyprlang::STRING const*> cache;
+
+    if (!cache.count(config))
+        cache[config] = (Hyprlang::STRING const*)HyprlandAPI::getConfigValue(
+                            PHANDLE,
+                            "plugin:hyprtasking:" + config
+                        )->getDataStaticPtr();
+    return *cache[config];
 }
 
 } // namespace HTConfig

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -33,12 +33,13 @@ bool HTManager::start_window_drag() {
     if (cursor_workspace == nullptr && workspace_id == WORKSPACE_INVALID) {
         const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
         if (grid_layout != nullptr && cursor_monitor->logicalBox().containsPoint(mouse_coords)) {
-            const auto [cell_x, cell_y] = grid_layout->get_grid_cell_from_global(mouse_coords);
-            if (cell_x >= 0 && cell_y >= 0) {
+            const auto [cell_x, cell_y, cell_layer] = grid_layout->get_grid_cell_from_global(mouse_coords);
+            if (cell_x >= 0 && cell_y >= 0 && cell_layer >= 0) {
+                grid_layout->layer = cell_layer;
                 const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
                 const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
                 const int ws_per_layer = std::max(1, ROWS * COLS);
-                const int target_slot = grid_layout->layer * ws_per_layer + cell_y * COLS + cell_x;
+                const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
                 WORKSPACEID next_id = 1;
                 for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
                     if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
@@ -163,37 +164,36 @@ bool HTManager::end_window_drag() {
                     cursor_workspace->m_id
                 );
             } else {
-                const auto [cell_x, cell_y] = grid_layout->get_grid_cell_from_global(mouse_coords);
-                if (cell_x < 0 || cell_y < 0) {
-                    g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
-                    return false;
-                }
+                const auto [cell_x, cell_y, cell_layer] = grid_layout->get_grid_cell_from_global(mouse_coords);
+                if (cell_x >= 0 && cell_y >= 0 && cell_layer >= 0) {
+                    grid_layout->layer = cell_layer;
 
-                const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-                const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-                const int ws_per_layer = std::max(1, ROWS * COLS);
-                const int target_slot = grid_layout->layer * ws_per_layer + cell_y * COLS + cell_x;
+                    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+                    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+                    const int ws_per_layer = std::max(1, ROWS * COLS);
+                    const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
-                WORKSPACEID next_id = 1;
-                for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-                    if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
-                        next_id = ws->m_id + 1;
+                    WORKSPACEID next_id = 1;
+                    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+                        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
+                            next_id = ws->m_id + 1;
+                        }
                     }
-                }
 
-                cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
-                if (cursor_workspace != nullptr) {
-                    grid_layout->pin_workspace_to_slot(next_id, target_slot);
-                    Log::logger->log(
-                        LOG,
-                        "[Hyprtasking] Created workspace {} at slot ({}, {}) for drop",
-                        next_id,
-                        cell_x,
-                        cell_y
-                    );
-                } else {
-                    g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
-                    return false;
+                    cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
+                    if (cursor_workspace != nullptr) {
+                        grid_layout->pin_workspace_to_slot(next_id, target_slot);
+                        Log::logger->log(
+                            LOG,
+                            "[Hyprtasking] Created workspace {} at slot ({}, {}) for drop",
+                            next_id,
+                            cell_x,
+                            cell_y
+                        );
+                    } else {
+                        g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+                        return false;
+                    }
                 }
             }
         } else {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -26,7 +26,7 @@ bool HTManager::start_window_drag() {
 
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
     const WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
-    PHLWORKSPACE cursor_workspace = g_pCompositor->getWorkspaceByID(workspace_id);
+    PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
 
     // If left click on non-workspace workspace, do nothing
     if (cursor_workspace == nullptr)
@@ -111,13 +111,20 @@ bool HTManager::end_window_drag() {
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
     Vector2D use_mouse_coords = mouse_coords;
     const WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
-    PHLWORKSPACE cursor_workspace = g_pCompositor->getWorkspaceByID(workspace_id);
+    PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
 
-    // Release on empty dummy workspace, so create and switch to it
-    if (cursor_workspace == nullptr && workspace_id != WORKSPACE_INVALID) {
-        cursor_workspace = g_pCompositor->createNewWorkspace(workspace_id, cursor_monitor->m_id);
-    } else if (workspace_id == WORKSPACE_INVALID) {
+    if (workspace_id == WORKSPACE_INVALID) {
         cursor_workspace = dragged_window->m_workspace;
+        if (cursor_workspace == nullptr
+            || cursor_view->layout->get_workspace_from_layout(cursor_workspace->m_id) == nullptr) {
+            cursor_workspace = nullptr;
+        }
+
+        if (cursor_workspace == nullptr) {
+            g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+            return false;
+        }
+
         // Ensure that the mouse coords are snapped to inside the workspace box itself
         use_mouse_coords = cursor_view->layout->get_global_ws_box(cursor_workspace->m_id)
                                .closestPoint(use_mouse_coords);
@@ -135,7 +142,13 @@ bool HTManager::end_window_drag() {
         return false;
     }
 
-    Log::logger->log(LOG, "[Hyprtasking] trying to drop window on ws {}", cursor_workspace->m_id);
+    Log::logger->log(
+        LOG,
+        "[Hyprtasking] trying to drop window on monitor {} ws {} ({})",
+        cursor_monitor->m_name,
+        cursor_workspace->m_id,
+        cursor_workspace->m_name
+    );
 
     // PHLWORKSPACEREF o_workspace = cursor_monitor->m_activeWorkspace;
     cursor_monitor->changeWorkspace(cursor_workspace, true);
@@ -262,6 +275,7 @@ bool HTManager::swipe_update(IPointer::SSwipeUpdateEvent e) {
                 return res;
             } else {
                 swipe_state = HT_SWIPE_MOVE;
+                cursor_view->layout->init_position();
                 cursor_view->navigating = true;
 
                 // need to schedule frames for monitor, otherwise the screen doesn't re-render

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -111,7 +111,7 @@ bool HTManager::end_window_drag() {
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
     Vector2D use_mouse_coords = mouse_coords;
     const WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
-    PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
+    PHLWORKSPACE cursor_workspace = cursor_view->layout->get_or_create_workspace_from_layout(workspace_id);
 
     if (workspace_id == WORKSPACE_INVALID) {
         cursor_workspace = dragged_window->m_workspace;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -29,6 +29,7 @@ bool HTManager::start_window_drag() {
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
     WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
     PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
+    bool hit_empty_grid_cell = false;
 
     // If left click on non-workspace workspace (empty cell), create workspace there
     if (cursor_workspace == nullptr && workspace_id == WORKSPACE_INVALID) {
@@ -36,14 +37,14 @@ bool HTManager::start_window_drag() {
         if (grid_layout != nullptr && cursor_monitor->logicalBox().containsPoint(mouse_coords)) {
             const auto [cell_x, cell_y, cell_layer] = grid_layout->get_grid_cell_from_global(mouse_coords);
             if (cell_x >= 0 && cell_y >= 0 && cell_layer >= 0) {
+                hit_empty_grid_cell = true;
                 grid_layout->layer = cell_layer;
                 const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
                 const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
-                // Starting a drag from an empty cell should not force a new id
-                // when the active workspace is empty and can be reused.
-                remember_empty_workspace(cursor_monitor->m_activeWorkspace, cursor_monitor);
+                // Create the target lazily only when dragging really enters an
+                // empty grid cell.
                 cursor_workspace = create_workspace_for_monitor(cursor_monitor);
                 if (cursor_workspace != nullptr) {
                     grid_layout->pin_workspace_to_slot(cursor_workspace->m_id, target_slot);
@@ -54,8 +55,10 @@ bool HTManager::start_window_drag() {
     }
 
     // If still no workspace, do nothing
+    // Still consume clicks on valid empty grid cells so failed allocation does
+    // not leak a mouse press through the overview.
     if (cursor_workspace == nullptr)
-        return false;
+        return hit_empty_grid_cell;
 
     // PHLWORKSPACEREF o_workspace = cursor_monitor->m_activeWorkspace;
     cursor_monitor->changeWorkspace(cursor_workspace, true);
@@ -225,11 +228,9 @@ bool HTManager::end_window_drag() {
     );
 
     // PHLWORKSPACEREF o_workspace = cursor_monitor->m_activeWorkspace;
-    const PHLWORKSPACE source_workspace = dragged_window->m_workspace;
     cursor_monitor->changeWorkspace(cursor_workspace, true);
 
     g_pCompositor->moveWindowToWorkspaceSafe(dragged_window, cursor_workspace);
-    remember_empty_workspace(source_workspace, cursor_monitor);
 
     const Vector2D workspace_coords =
         cursor_view->layout->global_to_local_ws_unscaled(use_mouse_coords, cursor_workspace->m_id)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -11,6 +11,7 @@
 #include "manager.hpp"
 #include "overview.hpp"
 #include "layout/grid.hpp"
+#include "workspace.hpp"
 
 bool HTManager::start_window_drag() {
     const PHLMONITOR cursor_monitor = g_pCompositor->getMonitorFromCursor();
@@ -40,16 +41,10 @@ bool HTManager::start_window_drag() {
                 const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
-                WORKSPACEID next_id = 1;
-                for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-                    if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
-                        next_id = ws->m_id + 1;
-                    }
-                }
-                cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
+                cursor_workspace = create_workspace_for_monitor(cursor_monitor);
                 if (cursor_workspace != nullptr) {
-                    grid_layout->pin_workspace_to_slot(next_id, target_slot);
-                    workspace_id = next_id;
+                    grid_layout->pin_workspace_to_slot(cursor_workspace->m_id, target_slot);
+                    workspace_id = cursor_workspace->m_id;
                 }
             }
         }
@@ -173,20 +168,13 @@ bool HTManager::end_window_drag() {
                     const int ws_per_layer = std::max(1, ROWS * COLS);
                     const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
-                    WORKSPACEID next_id = 1;
-                    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-                        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
-                            next_id = ws->m_id + 1;
-                        }
-                    }
-
-                    cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
+                    cursor_workspace = create_workspace_for_monitor(cursor_monitor);
                     if (cursor_workspace != nullptr) {
-                        grid_layout->pin_workspace_to_slot(next_id, target_slot);
+                        grid_layout->pin_workspace_to_slot(cursor_workspace->m_id, target_slot);
                         Log::logger->log(
                             LOG,
                             "[Hyprtasking] Created workspace {} at slot ({}, {}) for drop",
-                            next_id,
+                            cursor_workspace->m_id,
                             cell_x,
                             cell_y
                         );

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -41,6 +41,8 @@ bool HTManager::start_window_drag() {
                 const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
+                // Starting a drag from an empty cell should not force a new id
+                // when the active workspace is empty and can simply be reused.
                 if (can_reuse_empty_workspace(cursor_monitor->m_activeWorkspace, cursor_monitor))
                     cursor_workspace = cursor_monitor->m_activeWorkspace;
                 else

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -114,26 +114,46 @@ bool HTManager::end_window_drag() {
     PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
 
     if (workspace_id == WORKSPACE_INVALID) {
-        cursor_workspace = dragged_window->m_workspace;
-        if (cursor_workspace == nullptr
-            || cursor_view->layout->get_workspace_from_layout(cursor_workspace->m_id) == nullptr) {
-            cursor_workspace = nullptr;
+        if (cursor_monitor->logicalBox().containsPoint(mouse_coords)) {
+            WORKSPACEID next_id = 1;
+            for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+                if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
+                    next_id = ws->m_id + 1;
+                }
+            }
+
+            cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
+            if (cursor_workspace != nullptr) {
+                Log::logger->log(
+                    LOG,
+                    "[Hyprtasking] Created workspace {} for drop on empty cell",
+                    next_id
+                );
+            } else {
+                g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+                return false;
+            }
+        } else {
+            cursor_workspace = dragged_window->m_workspace;
+            if (cursor_workspace == nullptr
+                || cursor_view->layout->get_workspace_from_layout(cursor_workspace->m_id) == nullptr) {
+                cursor_workspace = nullptr;
+            }
+
+            if (cursor_workspace == nullptr) {
+                g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+                return false;
+            }
+
+            use_mouse_coords = cursor_view->layout->get_global_ws_box(cursor_workspace->m_id)
+                                   .closestPoint(use_mouse_coords);
+
+            Log::logger->log(
+                LOG,
+                "[Hyprtasking] Dragging to invalid position, snapping to last ws {}",
+                cursor_workspace->m_id
+            );
         }
-
-        if (cursor_workspace == nullptr) {
-            g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
-            return false;
-        }
-
-        // Ensure that the mouse coords are snapped to inside the workspace box itself
-        use_mouse_coords = cursor_view->layout->get_global_ws_box(cursor_workspace->m_id)
-                               .closestPoint(use_mouse_coords);
-
-        Log::logger->log(
-            LOG,
-            "[Hyprtasking] Dragging to invalid position, snapping to last ws {}",
-            cursor_workspace->m_id
-        );
     }
 
     if (cursor_workspace == nullptr) {

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -41,7 +41,10 @@ bool HTManager::start_window_drag() {
                 const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
-                cursor_workspace = create_workspace_for_monitor(cursor_monitor);
+                if (can_reuse_empty_workspace(cursor_monitor->m_activeWorkspace, cursor_monitor))
+                    cursor_workspace = cursor_monitor->m_activeWorkspace;
+                else
+                    cursor_workspace = create_workspace_for_monitor(cursor_monitor);
                 if (cursor_workspace != nullptr) {
                     grid_layout->pin_workspace_to_slot(cursor_workspace->m_id, target_slot);
                     workspace_id = cursor_workspace->m_id;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -13,6 +13,37 @@
 #include "layout/grid.hpp"
 #include "workspace.hpp"
 
+namespace {
+PHLWORKSPACE create_workspace_at_grid_cell(SP<HTLayoutGrid> grid, PHLMONITOR monitor, Vector2D pos) {
+    if (grid == nullptr || monitor == nullptr || !monitor->logicalBox().containsPoint(pos))
+        return nullptr;
+
+    const auto [cell_x, cell_y, cell_layer] = grid->get_grid_cell_from_global(pos);
+    if (cell_x < 0 || cell_y < 0 || cell_layer < 0)
+        return nullptr;
+
+    grid->layer = cell_layer;
+    const int ROWS = static_cast<Hyprlang::INT>(HTConfig::value("grid:rows"));
+    const int COLS = static_cast<Hyprlang::INT>(HTConfig::value("grid:cols"));
+    const int ws_per_layer = std::max(1, ROWS * COLS);
+    const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
+
+    PHLWORKSPACE workspace = create_workspace_for_monitor(monitor);
+    if (workspace != nullptr)
+        grid->pin_workspace_to_slot(workspace->m_id, target_slot);
+
+    return workspace;
+}
+
+bool is_valid_grid_cell(SP<HTLayoutGrid> grid, PHLMONITOR monitor, Vector2D pos) {
+    if (grid == nullptr || monitor == nullptr || !monitor->logicalBox().containsPoint(pos))
+        return false;
+
+    const auto [cell_x, cell_y, cell_layer] = grid->get_grid_cell_from_global(pos);
+    return cell_x >= 0 && cell_y >= 0 && cell_layer >= 0;
+}
+}
+
 bool HTManager::start_window_drag() {
     const PHLMONITOR cursor_monitor = g_pCompositor->getMonitorFromCursor();
     const PHTVIEW cursor_view = get_view_from_monitor(cursor_monitor);
@@ -21,7 +52,6 @@ bool HTManager::start_window_drag() {
         return false;
 
     if (!cursor_view->layout->should_manage_mouse()) {
-        // hide all views if should not manage mouse but active
         hide_all_views();
         return true;
     }
@@ -31,37 +61,22 @@ bool HTManager::start_window_drag() {
     PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
     bool hit_empty_grid_cell = false;
 
-    // If left click on non-workspace workspace (empty cell), create workspace there
     if (cursor_workspace == nullptr && workspace_id == WORKSPACE_INVALID) {
         const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
-        if (grid_layout != nullptr && cursor_monitor->logicalBox().containsPoint(mouse_coords)) {
-            const auto [cell_x, cell_y, cell_layer] = grid_layout->get_grid_cell_from_global(mouse_coords);
-            if (cell_x >= 0 && cell_y >= 0 && cell_layer >= 0) {
-                hit_empty_grid_cell = true;
-                grid_layout->layer = cell_layer;
-                const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-                const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-                const int ws_per_layer = std::max(1, ROWS * COLS);
-                const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
-                // Create the target lazily only when dragging really enters an
-                // empty grid cell.
-                cursor_workspace = create_workspace_for_monitor(cursor_monitor);
-                if (cursor_workspace != nullptr) {
-                    grid_layout->pin_workspace_to_slot(cursor_workspace->m_id, target_slot);
-                    workspace_id = cursor_workspace->m_id;
-                }
-            }
-        }
+        hit_empty_grid_cell = is_valid_grid_cell(grid_layout, cursor_monitor, mouse_coords);
+        cursor_workspace = create_workspace_at_grid_cell(grid_layout, cursor_monitor, mouse_coords);
+        if (cursor_workspace != nullptr)
+            workspace_id = cursor_workspace->m_id;
     }
 
-    // If still no workspace, do nothing
-    // Still consume clicks on valid empty grid cells so failed allocation does
-    // not leak a mouse press through the overview.
     if (cursor_workspace == nullptr)
         return hit_empty_grid_cell;
 
-    // PHLWORKSPACEREF o_workspace = cursor_monitor->m_activeWorkspace;
-    cursor_monitor->changeWorkspace(cursor_workspace, true);
+    const PHLMONITOR ws_monitor = g_pCompositor->getMonitorFromID(cursor_workspace->monitorID());
+    if (ws_monitor != nullptr)
+        ws_monitor->changeWorkspace(cursor_workspace, true);
+    else
+        cursor_monitor->changeWorkspace(cursor_workspace, true);
 
     const Vector2D workspace_coords =
         cursor_view->layout->global_to_local_ws_unscaled(mouse_coords, workspace_id)
@@ -98,9 +113,6 @@ bool HTManager::start_window_drag() {
         }
     }
 
-    // if (o_workspace != nullptr)
-    //     cursor_monitor->changeWorkspace(o_workspace.lock(), true);
-
     return true;
 }
 
@@ -112,13 +124,11 @@ bool HTManager::end_window_drag() {
         return false;
     }
 
-    // Required if dragging and dropping from active to inactive
     if (!cursor_view->active || cursor_view->closing) {
         g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
         return false;
     }
 
-    // For linear layout: if dropping on big workspace, just pass on
     if (!cursor_view->layout->should_manage_mouse()) {
         g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
         return false;
@@ -128,8 +138,6 @@ bool HTManager::end_window_drag() {
     if (target == nullptr)
         return false;
 
-    // If not dragging window or drag is not move, then we just let go (supposed to prevent it
-    // from messing up resize on border, but it should be good because above?)
     const PHLWINDOW dragged_window = target->window();
     if (dragged_window == nullptr || g_layoutManager->dragController()->mode() != MBIND_MOVE) {
         g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
@@ -165,29 +173,11 @@ bool HTManager::end_window_drag() {
                     cursor_workspace->m_id
                 );
             } else {
-                const auto [cell_x, cell_y, cell_layer] = grid_layout->get_grid_cell_from_global(mouse_coords);
-                if (cell_x >= 0 && cell_y >= 0 && cell_layer >= 0) {
-                    grid_layout->layer = cell_layer;
-
-                    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-                    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-                    const int ws_per_layer = std::max(1, ROWS * COLS);
-                    const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
-
-                    cursor_workspace = create_workspace_for_monitor(cursor_monitor);
-                    if (cursor_workspace != nullptr) {
-                        grid_layout->pin_workspace_to_slot(cursor_workspace->m_id, target_slot);
-                        Log::logger->log(
-                            LOG,
-                            "[Hyprtasking] Created workspace {} at slot ({}, {}) for drop",
-                            cursor_workspace->m_id,
-                            cell_x,
-                            cell_y
-                        );
-                    } else {
-                        g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
-                        return false;
-                    }
+                const bool hit_empty_grid_cell = is_valid_grid_cell(grid_layout, cursor_monitor, mouse_coords);
+                cursor_workspace = create_workspace_at_grid_cell(grid_layout, cursor_monitor, mouse_coords);
+                if (cursor_workspace == nullptr && hit_empty_grid_cell) {
+                    g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+                    return false;
                 }
             }
         } else {
@@ -227,8 +217,11 @@ bool HTManager::end_window_drag() {
         cursor_workspace->m_name
     );
 
-    // PHLWORKSPACEREF o_workspace = cursor_monitor->m_activeWorkspace;
-    cursor_monitor->changeWorkspace(cursor_workspace, true);
+    const PHLMONITOR drop_monitor = g_pCompositor->getMonitorFromID(cursor_workspace->monitorID());
+    if (drop_monitor != nullptr)
+        drop_monitor->changeWorkspace(cursor_workspace, true);
+    else
+        cursor_monitor->changeWorkspace(cursor_workspace, true);
 
     g_pCompositor->moveWindowToWorkspaceSafe(dragged_window, cursor_workspace);
 
@@ -241,13 +234,8 @@ bool HTManager::end_window_drag() {
     g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
     g_pPointerManager->warpTo(mouse_coords);
 
-    // otherwise the window leaves blur (?) artifacts on all
-    // workspaces
     dragged_window->m_movingToWorkspaceAlpha->setValueAndWarp(1.0);
     dragged_window->m_movingFromWorkspaceAlpha->setValueAndWarp(1.0);
-
-    // if (o_workspace != nullptr)
-    //     cursor_monitor->changeWorkspace(o_workspace.lock(), true);
 
     // Do not return true and cancel the event! Mouse release requires some stuff to be done for
     // floating windows to be unfocused properly
@@ -293,14 +281,14 @@ bool HTManager::swipe_update(IPointer::SSwipeUpdateEvent e) {
     if (cursor_view == nullptr)
         return false;
 
-    const int ENABLED = HTConfig::value<Hyprlang::INT>("gestures:enabled");
+    const int ENABLED = static_cast<Hyprlang::INT>(HTConfig::value("gestures:enabled"));
     if (!ENABLED)
         return false;
 
-    const unsigned int MOVE_FINGERS = HTConfig::value<Hyprlang::INT>("gestures:move_fingers");
-    const float OPEN_DISTANCE = HTConfig::value<Hyprlang::FLOAT>("gestures:open_distance");
-    const unsigned int OPEN_FINGERS = HTConfig::value<Hyprlang::INT>("gestures:open_fingers");
-    const int OPEN_POSITIVE = HTConfig::value<Hyprlang::INT>("gestures:open_positive");
+    const unsigned int MOVE_FINGERS = static_cast<Hyprlang::INT>(HTConfig::value("gestures:move_fingers"));
+    const float OPEN_DISTANCE = HTConfig::value_float("gestures:open_distance");
+    const unsigned int OPEN_FINGERS = static_cast<Hyprlang::INT>(HTConfig::value("gestures:open_fingers"));
+    const int OPEN_POSITIVE = static_cast<Hyprlang::INT>(HTConfig::value("gestures:open_positive"));
 
     bool res = false;
     char swipe_direction = 0;
@@ -368,7 +356,7 @@ bool HTManager::swipe_end() {
 
     switch (swipe_state) {
         case HT_SWIPE_OPEN: {
-            const float OPEN_DISTANCE = HTConfig::value<Hyprlang::FLOAT>("gestures:open_distance");
+            const float OPEN_DISTANCE = HTConfig::value_float("gestures:open_distance");
             const float swipe_perc = 1.0 - std::clamp(swipe_amt / OPEN_DISTANCE, 0.01f, 1.0f);
             if (swipe_perc >= 0.5) {
                 cursor_view->show(false);

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -42,11 +42,9 @@ bool HTManager::start_window_drag() {
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
                 // Starting a drag from an empty cell should not force a new id
-                // when the active workspace is empty and can simply be reused.
-                if (can_reuse_empty_workspace(cursor_monitor->m_activeWorkspace, cursor_monitor))
-                    cursor_workspace = cursor_monitor->m_activeWorkspace;
-                else
-                    cursor_workspace = create_workspace_for_monitor(cursor_monitor);
+                // when the active workspace is empty and can be reused.
+                remember_empty_workspace(cursor_monitor->m_activeWorkspace, cursor_monitor);
+                cursor_workspace = create_workspace_for_monitor(cursor_monitor);
                 if (cursor_workspace != nullptr) {
                     grid_layout->pin_workspace_to_slot(cursor_workspace->m_id, target_slot);
                     workspace_id = cursor_workspace->m_id;
@@ -227,9 +225,11 @@ bool HTManager::end_window_drag() {
     );
 
     // PHLWORKSPACEREF o_workspace = cursor_monitor->m_activeWorkspace;
+    const PHLWORKSPACE source_workspace = dragged_window->m_workspace;
     cursor_monitor->changeWorkspace(cursor_workspace, true);
 
     g_pCompositor->moveWindowToWorkspaceSafe(dragged_window, cursor_workspace);
+    remember_empty_workspace(source_workspace, cursor_monitor);
 
     const Vector2D workspace_coords =
         cursor_view->layout->global_to_local_ws_unscaled(use_mouse_coords, cursor_workspace->m_id)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -10,6 +10,7 @@
 #include "config.hpp"
 #include "manager.hpp"
 #include "overview.hpp"
+#include "layout/grid.hpp"
 
 bool HTManager::start_window_drag() {
     const PHLMONITOR cursor_monitor = g_pCompositor->getMonitorFromCursor();
@@ -115,23 +116,60 @@ bool HTManager::end_window_drag() {
 
     if (workspace_id == WORKSPACE_INVALID) {
         if (cursor_monitor->logicalBox().containsPoint(mouse_coords)) {
-            WORKSPACEID next_id = 1;
-            for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-                if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
-                    next_id = ws->m_id + 1;
+            const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
+            if (grid_layout == nullptr) {
+                cursor_workspace = dragged_window->m_workspace;
+                if (cursor_workspace == nullptr
+                    || cursor_view->layout->get_workspace_from_layout(cursor_workspace->m_id) == nullptr) {
+                    cursor_workspace = nullptr;
                 }
-            }
 
-            cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
-            if (cursor_workspace != nullptr) {
+                if (cursor_workspace == nullptr) {
+                    g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+                    return false;
+                }
+
+                use_mouse_coords = cursor_view->layout->get_global_ws_box(cursor_workspace->m_id)
+                                       .closestPoint(use_mouse_coords);
+
                 Log::logger->log(
                     LOG,
-                    "[Hyprtasking] Created workspace {} for drop on empty cell",
-                    next_id
+                    "[Hyprtasking] Dragging to invalid position, snapping to last ws {}",
+                    cursor_workspace->m_id
                 );
             } else {
-                g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
-                return false;
+                const auto [cell_x, cell_y] = grid_layout->get_grid_cell_from_global(mouse_coords);
+                if (cell_x < 0 || cell_y < 0) {
+                    g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+                    return false;
+                }
+
+                const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+                const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+                const int ws_per_layer = std::max(1, ROWS * COLS);
+                const int target_slot = grid_layout->layer * ws_per_layer + cell_y * COLS + cell_x;
+
+                WORKSPACEID next_id = 1;
+                for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+                    if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
+                        next_id = ws->m_id + 1;
+                    }
+                }
+
+                cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
+                if (cursor_workspace != nullptr) {
+                    grid_layout->pin_workspace_to_slot(next_id, target_slot);
+                    Log::logger->log(
+                        LOG,
+                        "[Hyprtasking] Created workspace {} at slot ({}, {}) for drop",
+                        next_id,
+                        cell_x,
+                        cell_y
+                    );
+                } else {
+                    g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+                    return false;
+                }
             }
         } else {
             cursor_workspace = dragged_window->m_workspace;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -245,6 +245,36 @@ bool HTManager::end_window_drag() {
     return false;
 }
 
+bool HTManager::mark_workspace() {
+    const PHLMONITOR cursor_monitor = g_pCompositor->getMonitorFromCursor();
+    const PHTVIEW cursor_view = get_view_from_monitor(cursor_monitor);
+    if (cursor_monitor == nullptr || cursor_view == nullptr || !cursor_view->active
+        || cursor_view->closing)
+        return false;
+
+    if (!cursor_view->layout->should_manage_mouse())
+        return false;
+
+    const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
+    WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
+    PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
+    bool hit_empty_grid_cell = false;
+
+    if (cursor_workspace == nullptr && workspace_id == WORKSPACE_INVALID) {
+        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
+        hit_empty_grid_cell = is_valid_grid_cell(grid_layout, cursor_monitor, mouse_coords);
+        cursor_workspace = create_workspace_at_grid_cell(grid_layout, cursor_monitor, mouse_coords);
+        if (cursor_workspace != nullptr)
+            workspace_id = cursor_workspace->m_id;
+    }
+
+    if (cursor_workspace == nullptr)
+        return hit_empty_grid_cell;
+
+    cursor_view->mark_workspace(cursor_workspace->m_id);
+    return true;
+}
+
 bool HTManager::exit_to_workspace() {
     const PHTVIEW cursor_view = get_view_from_cursor();
     if (cursor_view == nullptr)

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -111,7 +111,7 @@ bool HTManager::end_window_drag() {
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
     Vector2D use_mouse_coords = mouse_coords;
     const WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
-    PHLWORKSPACE cursor_workspace = cursor_view->layout->get_or_create_workspace_from_layout(workspace_id);
+    PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
 
     if (workspace_id == WORKSPACE_INVALID) {
         cursor_workspace = dragged_window->m_workspace;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -78,6 +78,9 @@ bool HTManager::start_window_drag() {
     else
         cursor_monitor->changeWorkspace(cursor_workspace, true);
 
+    if (cursor_view != nullptr && cursor_view->active)
+        cursor_view->hide(true);
+
     const Vector2D workspace_coords =
         cursor_view->layout->global_to_local_ws_unscaled(mouse_coords, workspace_id)
         + cursor_monitor->m_position;

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -26,10 +26,35 @@ bool HTManager::start_window_drag() {
     }
 
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
-    const WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
+    WORKSPACEID workspace_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
     PHLWORKSPACE cursor_workspace = cursor_view->layout->get_workspace_from_layout(workspace_id);
 
-    // If left click on non-workspace workspace, do nothing
+    // If left click on non-workspace workspace (empty cell), create workspace there
+    if (cursor_workspace == nullptr && workspace_id == WORKSPACE_INVALID) {
+        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
+        if (grid_layout != nullptr && cursor_monitor->logicalBox().containsPoint(mouse_coords)) {
+            const auto [cell_x, cell_y] = grid_layout->get_grid_cell_from_global(mouse_coords);
+            if (cell_x >= 0 && cell_y >= 0) {
+                const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+                const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+                const int ws_per_layer = std::max(1, ROWS * COLS);
+                const int target_slot = grid_layout->layer * ws_per_layer + cell_y * COLS + cell_x;
+                WORKSPACEID next_id = 1;
+                for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+                    if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
+                        next_id = ws->m_id + 1;
+                    }
+                }
+                cursor_workspace = g_pCompositor->createNewWorkspace(next_id, cursor_monitor->m_id, "", false);
+                if (cursor_workspace != nullptr) {
+                    grid_layout->pin_workspace_to_slot(next_id, target_slot);
+                    workspace_id = next_id;
+                }
+            }
+        }
+    }
+
+    // If still no workspace, do nothing
     if (cursor_workspace == nullptr)
         return false;
 

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -1,5 +1,7 @@
 #include "grid.hpp"
 
+#include <algorithm>
+
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/config/ConfigValue.hpp>
@@ -44,6 +46,29 @@ HTLayoutGrid::HTLayoutGrid(VIEWID new_view_id) : HTLayoutBase(new_view_id) {
 
 std::string HTLayoutGrid::layout_name() {
     return "grid";
+}
+
+int HTLayoutGrid::get_effective_layer_count(size_t workspace_count) {
+    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int LAYERS = HTConfig::value<Hyprlang::INT>("grid:layers");
+    const int ws_per_layer = std::max(1, ROWS * COLS);
+    const int configured_layers = std::max(1, LAYERS);
+    const int needed_layers = std::max(1, (int)(workspace_count + ws_per_layer - 1) / ws_per_layer);
+    return std::max(configured_layers, needed_layers);
+}
+
+int HTLayoutGrid::get_workspace_layer(WORKSPACEID workspace_id) {
+    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int ws_per_layer = std::max(1, ROWS * COLS);
+    const std::vector<PHLWORKSPACE> workspaces = get_monitor_workspaces();
+
+    for (size_t i = 0; i < workspaces.size(); i++) {
+        if (workspaces[i] != nullptr && workspaces[i]->m_id == workspace_id)
+            return (int)i / ws_per_layer;
+    }
+    return layer;
 }
 
 WORKSPACEID HTLayoutGrid::get_ws_id_in_direction(int x, int y, std::string& direction) {
@@ -115,9 +140,13 @@ void HTLayoutGrid::close_open_lerp(float perc) {
         calculate_ws_box(0, 0, HT_VIEW_OPENED).w / monitor->m_transformedSize.x; // 1 / ROWS
     Vector2D open_pos = {0, 0};
 
+    layer = get_workspace_layer(monitor->m_activeWorkspace->m_id);
     build_overview_layout(HT_VIEW_CLOSED);
     double close_scale = 1.;
-    Vector2D close_pos = -overview_layout[monitor->m_activeWorkspace->m_id].box.pos();
+    const auto active_it = overview_layout.find(monitor->m_activeWorkspace->m_id);
+    if (active_it == overview_layout.end())
+        return;
+    Vector2D close_pos = -active_it->second.box.pos();
 
     double new_scale = std::lerp(close_scale, open_scale, perc);
     Vector2D new_pos = Vector2D {
@@ -156,10 +185,14 @@ void HTLayoutGrid::on_hide(CallbackFun on_complete) {
     if (monitor == nullptr)
         return;
 
+    layer = get_workspace_layer(monitor->m_activeWorkspace->m_id);
     build_overview_layout(HT_VIEW_CLOSED);
     *scale = 1.;
     // End workspace to end up on
-    *offset = -overview_layout[monitor->m_activeWorkspace->m_id].box.pos();
+    const auto active_it = overview_layout.find(monitor->m_activeWorkspace->m_id);
+    if (active_it == overview_layout.end())
+        return;
+    *offset = -active_it->second.box.pos();
 }
 
 void HTLayoutGrid::on_move(WORKSPACEID old_id, WORKSPACEID new_id, CallbackFun on_complete) {
@@ -172,14 +205,23 @@ void HTLayoutGrid::on_move(WORKSPACEID old_id, WORKSPACEID new_id, CallbackFun o
     if (par_view == nullptr || par_view->active)
         return;
 
-    // prevent the thing from animating
-    g_pCompositor->getWorkspaceByID(old_id)->m_renderOffset->warp();
-    g_pCompositor->getWorkspaceByID(new_id)->m_renderOffset->warp();
+    const PHLWORKSPACE old_workspace = g_pCompositor->getWorkspaceByID(old_id);
+    const PHLWORKSPACE new_workspace = g_pCompositor->getWorkspaceByID(new_id);
+    if (old_workspace == nullptr || new_workspace == nullptr)
+        return;
 
+    // prevent the thing from animating
+    old_workspace->m_renderOffset->warp();
+    new_workspace->m_renderOffset->warp();
+
+    layer = get_workspace_layer(new_id);
     build_overview_layout(HT_VIEW_CLOSED);
     *scale = 1.;
     // Target workspace to animate to
-    *offset = -overview_layout[new_id].box.pos();
+    const auto target_it = overview_layout.find(new_id);
+    if (target_it == overview_layout.end())
+        return;
+    *offset = -target_it->second.box.pos();
 }
 
 bool HTLayoutGrid::should_render_window(PHLWINDOW window) {
@@ -218,6 +260,7 @@ void HTLayoutGrid::init_position() {
     if (monitor->m_activeWorkspace == nullptr)
         return;
 
+    layer = get_workspace_layer(monitor->m_activeWorkspace->m_id);
     build_overview_layout(HT_VIEW_CLOSED);
 
     const auto it = overview_layout.find(monitor->m_activeWorkspace->m_id);
@@ -287,39 +330,33 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-    const int LAYERS = HTConfig::value<Hyprlang::INT>("grid:layers");
-
-    const PHLMONITOR last_monitor = Desktop::focusState()->monitor();
-    Desktop::focusState()->rawMonitorFocus(monitor);
+    const std::vector<PHLWORKSPACE> workspaces = get_monitor_workspaces();
+    const int ws_per_layer = std::max(1, ROWS * COLS);
+    const int effective_layers = get_effective_layer_count(workspaces.size());
+    layer = std::clamp(layer, 0, effective_layers - 1);
 
     overview_layout.clear();
 
-    // ROWS*COLS workspaces
-    //           per layer
-    //           per monitor
-    //       M1
-    //  L1       L2
-    // 1  2     5  6
-    // 3  4     7  8
-    //       M2
-    //  L1       L2
-    // 9  10    13 14
-    // 11 12    15 16
-    const int ws_per_layer = ROWS*COLS;
-    for (int y = 0; y < ROWS; y++) {
-        for (int x = 0; x < COLS; x++) {
-            const WORKSPACEID ws_id = view_id * ws_per_layer * LAYERS + layer * ws_per_layer + y * ROWS + x + 1;
-            const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(ws_id);
-            if (workspace != nullptr && workspace->monitorID() != view_id) {
-                g_pCompositor->moveWorkspaceToMonitor(workspace, monitor);
-            }
-            const CBox ws_box = calculate_ws_box(x, y, stage);
-            overview_layout[ws_id] = HTWorkspace {x, y, ws_box};
-        }
-    }
+    const size_t start = layer * ws_per_layer;
+    const size_t end = std::min(start + ws_per_layer, workspaces.size());
+    for (size_t i = start; i < end; i++) {
+        const PHLWORKSPACE workspace = workspaces[i];
+        if (workspace == nullptr)
+            continue;
 
-    if (last_monitor != nullptr)
-        Desktop::focusState()->rawMonitorFocus(last_monitor);
+        const int local_i = (int)(i - start);
+        const int x = local_i % COLS;
+        const int y = local_i / COLS;
+        const CBox ws_box = calculate_ws_box(x, y, stage);
+        overview_layout[workspace->m_id] = HTWorkspace {
+            x,
+            y,
+            ws_box,
+            workspace->m_id,
+            workspace->m_name,
+            monitor->m_id,
+        };
+    }
 }
 
 void HTLayoutGrid::render() {
@@ -356,6 +393,8 @@ void HTLayoutGrid::render() {
     // Do a dance with active workspaces: Hyprland will only properly render the
     // current active one so make the workspace active before rendering it, etc
     const PHLWORKSPACE start_workspace = monitor->m_activeWorkspace;
+    if (start_workspace == nullptr)
+        return;
 
     g_pDesktopAnimationManager->startAnimation(
         start_workspace,
@@ -374,7 +413,7 @@ void HTLayoutGrid::render() {
             continue;
 
         // Could be nullptr, in which we render only layers
-        const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(ws_id);
+        const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
 
         // renderModif translation used by renderWorkspace is weird so need
         // to scale the translation up as well. Geometry is also calculated from pixel size and not transformed size??
@@ -391,7 +430,7 @@ void HTLayoutGrid::render() {
             continue;
 
         const CGradientValueData border_col =
-            monitor->m_activeWorkspace->m_id == ws_id ? *ACTIVECOL : *INACTIVECOL;
+            start_workspace->m_id == ws_id ? *ACTIVECOL : *INACTIVECOL;
         CBox border_box = ws_layout.box;
 
         CBorderPassElement::SBorderData data;
@@ -447,8 +486,9 @@ void HTLayoutGrid::render() {
     start_workspace->m_visible = true;
 
     // Render active workspace last so the dragging window is always on top when let go of
-    if (start_workspace != nullptr && overview_layout.count(start_workspace->m_id)) {
-        CBox ws_box = overview_layout[start_workspace->m_id].box;
+    const auto active_it = overview_layout.find(start_workspace->m_id);
+    if (start_workspace != nullptr && active_it != overview_layout.end()) {
+        CBox ws_box = active_it->second.box;
         // make sure box is not empty
         if (ws_box.width > 0.01 && ws_box.height > 0.01) {
             // renderModif translation used by renderWorkspace is weird so need

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -464,7 +464,7 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
                 auto& cell = grid_cells[l][y][x];
                 if (cell.ws_id != WORKSPACE_INVALID) {
                     const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(cell.ws_id);
-                    if (workspace == nullptr || workspace->inert() || workspace->m_isSpecialWorkspace) {
+                    if (!is_monitor_workspace(workspace)) {
                         cell.ws_id = WORKSPACE_INVALID;
                         cell.occupied = false;
                         cell.is_pinned = false;

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -337,48 +337,24 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     overview_layout.clear();
 
-    const size_t visible_slots = (size_t)ws_per_layer;
     const size_t start = layer * ws_per_layer;
-    const size_t placeholders_needed = start + visible_slots > workspaces.size()
-        ? start + visible_slots - workspaces.size()
-        : 0;
-    const std::vector<WORKSPACEID> placeholder_ids = get_available_workspace_ids(placeholders_needed);
+    const size_t end = std::min(start + ws_per_layer, workspaces.size());
+    for (size_t i = start; i < end; i++) {
+        const PHLWORKSPACE workspace = workspaces[i];
+        if (workspace == nullptr)
+            continue;
 
-    for (size_t local_i = 0; local_i < visible_slots; local_i++) {
-        const size_t workspace_i = start + local_i;
+        const int local_i = (int)(i - start);
         const int x = local_i % COLS;
         const int y = local_i / COLS;
         const CBox ws_box = calculate_ws_box(x, y, stage);
-
-        if (workspace_i < workspaces.size()) {
-            const PHLWORKSPACE workspace = workspaces[workspace_i];
-            if (workspace == nullptr)
-                continue;
-            overview_layout[workspace->m_id] = HTWorkspace {
-                x,
-                y,
-                ws_box,
-                workspace->m_id,
-                workspace->m_name,
-                monitor->m_id,
-                false,
-            };
-            continue;
-        }
-
-        const size_t placeholder_i = workspace_i - workspaces.size();
-        if (placeholder_i >= placeholder_ids.size())
-            continue;
-
-        const WORKSPACEID placeholder_id = placeholder_ids[placeholder_i];
-        overview_layout[placeholder_id] = HTWorkspace {
+        overview_layout[workspace->m_id] = HTWorkspace {
             x,
             y,
             ws_box,
-            placeholder_id,
-            std::to_string(placeholder_id),
+            workspace->m_id,
+            workspace->m_name,
             monitor->m_id,
-            true,
         };
     }
 }

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -631,14 +631,7 @@ void HTLayoutGrid::render() {
         }
     }
 
-    monitor->m_activeWorkspace = start_workspace;
-    g_pDesktopAnimationManager->startAnimation(
-        start_workspace,
-        CDesktopAnimationManager::ANIMATION_TYPE_IN,
-        false,
-        true
-    );
-    start_workspace->m_visible = true;
+    // CScopeGuard restore_workspace handles the final cleanup above
 
     const auto active_it = overview_layout.find(start_workspace->m_id);
     if (start_workspace != nullptr && active_it != overview_layout.end()) {

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -473,6 +473,9 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         return lhs.first < rhs.first;
     });
 
+    // Reserve every still-valid pinned slot first, even if the workspace is not
+    // currently on this monitor. This prevents monitor switches from causing
+    // unrelated workspaces to reflow into positions that should stay stable.
     for (const auto& [ws_id, slot] : pinned_slots) {
         if (slot >= 0 && slot < total_slots && !slot_occupied[slot])
             slot_occupied[slot] = true;
@@ -510,6 +513,8 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         slot_to_ws[next_free] = workspace->m_id;
         slot_occupied[next_free] = true;
         ws_to_slot[workspace->m_id] = next_free;
+        // Remember auto-placed workspaces so the next rebuild keeps the same
+        // order instead of depending on transient compositor workspace lists.
         pinned_positions[workspace->m_id] = next_free;
         ++next_free;
     }
@@ -610,6 +615,7 @@ void HTLayoutGrid::render() {
                 ws_box = calculate_ws_box(x, y, HT_VIEW_ANIMATING);
             }
 
+            // Skip if the box is empty
             if (ws_box.width < 0.01 || ws_box.height < 0.01)
                 continue;
 
@@ -667,6 +673,7 @@ void HTLayoutGrid::render() {
                     workspace->m_visible = false;
                 }
             } else {
+                // If a workspace is not allocated, then just render the layers
                 ((render_workspace_t)(render_workspace_hook->m_original))(
                     g_pHyprRenderer.get(),
                     monitor,

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -471,6 +471,8 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
             if (slot >= 0 && slot < total_slots && slot_to_ws[slot] == WORKSPACE_INVALID) {
                 slot_to_ws[slot] = workspace->m_id;
                 ws_to_slot[workspace->m_id] = slot;
+            } else {
+                pinned_positions.erase(pin_it);
             }
         }
     }
@@ -482,9 +484,6 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         if (ws_to_slot.contains(workspace->m_id))
             continue;
 
-        if (pinned_positions.contains(workspace->m_id))
-            continue;
-
         while (next_free < total_slots && slot_to_ws[next_free] != WORKSPACE_INVALID)
             ++next_free;
 
@@ -493,6 +492,7 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
         slot_to_ws[next_free] = workspace->m_id;
         ws_to_slot[workspace->m_id] = next_free;
+        pinned_positions[workspace->m_id] = next_free;
         ++next_free;
     }
 

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -49,6 +49,13 @@ std::string HTLayoutGrid::layout_name() {
 }
 
 void HTLayoutGrid::pin_workspace_to_slot(WORKSPACEID ws_id, int slot) {
+    for (auto it = pinned_positions.begin(); it != pinned_positions.end(); ) {
+        if (it->first != ws_id && it->second == slot)
+            it = pinned_positions.erase(it);
+        else
+            ++it;
+    }
+
     pinned_positions[ws_id] = slot;
 }
 
@@ -114,10 +121,53 @@ int HTLayoutGrid::get_workspace_layer(WORKSPACEID workspace_id) {
     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
     const int ws_per_layer = std::max(1, ROWS * COLS);
     const std::vector<PHLWORKSPACE> workspaces = get_monitor_workspaces();
+    std::vector<WORKSPACEID> workspace_ids;
+    workspace_ids.reserve(workspaces.size());
 
-    for (size_t i = 0; i < workspaces.size(); i++) {
-        if (workspaces[i] != nullptr && workspaces[i]->m_id == workspace_id)
-            return (int)i / ws_per_layer;
+    for (PHLWORKSPACE workspace : workspaces) {
+        if (workspace != nullptr)
+            workspace_ids.push_back(workspace->m_id);
+    }
+
+    std::ranges::sort(workspace_ids);
+
+    int max_slot = -1;
+    for (const auto& [ws_id, slot] : pinned_positions) {
+        if (g_pCompositor->getWorkspaceByID(ws_id) != nullptr && slot > max_slot)
+            max_slot = slot;
+    }
+
+    const int effective_layers = std::max(get_effective_layer_count(workspace_ids.size()), max_slot / ws_per_layer + 1);
+    std::vector<WORKSPACEID> slot_to_ws(effective_layers * ws_per_layer, WORKSPACE_INVALID);
+
+    for (WORKSPACEID ws_id : workspace_ids) {
+        pin_it = pinned_positions.find(ws_id);
+        if (pin_it == pinned_positions.end())
+            continue;
+
+        if (pin_it->second >= 0 && pin_it->second < (int)slot_to_ws.size()
+            && slot_to_ws[pin_it->second] == WORKSPACE_INVALID) {
+            slot_to_ws[pin_it->second] = ws_id;
+        }
+    }
+
+    size_t next_free = 0;
+    for (WORKSPACEID ws_id : workspace_ids) {
+        if (pinned_positions.contains(ws_id))
+            continue;
+
+        while (next_free < slot_to_ws.size() && slot_to_ws[next_free] != WORKSPACE_INVALID)
+            ++next_free;
+
+        if (next_free >= slot_to_ws.size())
+            break;
+
+        slot_to_ws[next_free] = ws_id;
+    }
+
+    for (size_t slot = 0; slot < slot_to_ws.size(); ++slot) {
+        if (slot_to_ws[slot] == workspace_id)
+            return (int)slot / ws_per_layer;
     }
 
     return layer;
@@ -385,7 +435,14 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-    const std::vector<PHLWORKSPACE> workspaces = get_monitor_workspaces();
+    std::vector<PHLWORKSPACE> workspaces = get_monitor_workspaces();
+    std::ranges::sort(workspaces, [](const PHLWORKSPACE& lhs, const PHLWORKSPACE& rhs) {
+        if (lhs == nullptr)
+            return false;
+        if (rhs == nullptr)
+            return true;
+        return lhs->m_id < rhs->m_id;
+    });
     const int ws_per_layer = std::max(1, ROWS * COLS);
     const int effective_layers = get_effective_layer_count(workspaces.size());
     layer = std::clamp(layer, 0, effective_layers - 1);
@@ -393,16 +450,15 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
     overview_layout.clear();
 
     for (auto it = pinned_positions.begin(); it != pinned_positions.end(); ) {
-        if (g_pCompositor->getWorkspaceByID(it->first) == nullptr)
+        const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(it->first);
+        if (!is_monitor_workspace(workspace))
             it = pinned_positions.erase(it);
         else
             ++it;
     }
 
-    const int layer_start = layer * ws_per_layer;
-    const int layer_end = layer_start + ws_per_layer;
-
-    std::vector<bool> slot_occupied(ws_per_layer, false);
+    const int total_slots = effective_layers * ws_per_layer;
+    std::vector<WORKSPACEID> slot_to_ws(total_slots, WORKSPACE_INVALID);
     std::unordered_map<WORKSPACEID, int> ws_to_slot;
 
     for (PHLWORKSPACE workspace : workspaces) {
@@ -411,41 +467,41 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
         auto pin_it = pinned_positions.find(workspace->m_id);
         if (pin_it != pinned_positions.end()) {
-            int slot = pin_it->second;
-            if (slot >= layer_start && slot < layer_end) {
-                int local_i = slot - layer_start;
-                slot_occupied[local_i] = true;
+            const int slot = pin_it->second;
+            if (slot >= 0 && slot < total_slots && slot_to_ws[slot] == WORKSPACE_INVALID) {
+                slot_to_ws[slot] = workspace->m_id;
                 ws_to_slot[workspace->m_id] = slot;
             }
         }
     }
 
-    int next_free = layer_start;
+    int next_free = 0;
     for (PHLWORKSPACE workspace : workspaces) {
         if (workspace == nullptr)
             continue;
         if (ws_to_slot.contains(workspace->m_id))
             continue;
 
-        auto pin_it = pinned_positions.find(workspace->m_id);
-        if (pin_it != pinned_positions.end()) {
-            // Skip workspaces pinned to other layers
+        if (pinned_positions.contains(workspace->m_id))
             continue;
-        }
 
-        while (next_free < layer_end && slot_occupied[next_free - layer_start])
+        while (next_free < total_slots && slot_to_ws[next_free] != WORKSPACE_INVALID)
             ++next_free;
 
-        if (next_free >= layer_end)
+        if (next_free >= total_slots)
             break;
 
-        slot_occupied[next_free - layer_start] = true;
+        slot_to_ws[next_free] = workspace->m_id;
         ws_to_slot[workspace->m_id] = next_free;
         ++next_free;
     }
 
-
     for (const auto& [ws_id, slot] : ws_to_slot) {
+        const int layer_start = layer * ws_per_layer;
+        const int layer_end = layer_start + ws_per_layer;
+        if (slot < layer_start || slot >= layer_end)
+            continue;
+
         int local_i = slot - layer_start;
         int x = local_i % COLS;
         int y = local_i / COLS;
@@ -591,14 +647,6 @@ void HTLayoutGrid::render() {
                         true
                     );
                     workspace->m_visible = false;
-                } else {
-                    ((render_workspace_t)(render_workspace_hook->m_original))(
-                        g_pHyprRenderer.get(),
-                        monitor,
-                        workspace,
-                        time,
-                        render_box
-                    );
                 }
             } else {
                 ((render_workspace_t)(render_workspace_hook->m_original))(

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -56,13 +56,13 @@ void HTLayoutGrid::unpin_workspace(WORKSPACEID ws_id) {
     pinned_positions.erase(ws_id);
 }
 
-std::pair<int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) {
+std::tuple<int, int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) {
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
-        return {-1, -1};
+        return {-1, -1, -1};
 
     if (!monitor->logicalBox().containsPoint(pos))
-        return {-1, -1};
+        return {-1, -1, -1};
 
     build_overview_layout(HT_VIEW_ANIMATING);
 
@@ -75,11 +75,11 @@ std::pair<int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) {
         for (int x = 0; x < COLS; x++) {
             CBox box = calculate_ws_box(x, y, HT_VIEW_ANIMATING);
             if (!box.empty() && box.containsPoint(rel))
-                return {x, y};
+                return {x, y, layer};
         }
     }
 
-    return {-1, -1};
+    return {-1, -1, -1};
 }
 
 int HTLayoutGrid::get_effective_layer_count(size_t workspace_count) {
@@ -88,7 +88,16 @@ int HTLayoutGrid::get_effective_layer_count(size_t workspace_count) {
     const int LAYERS = HTConfig::value<Hyprlang::INT>("grid:layers");
     const int ws_per_layer = std::max(1, ROWS * COLS);
     const int configured_layers = std::max(1, LAYERS);
-    const int needed_layers = std::max(1, (int)(workspace_count + ws_per_layer - 1) / ws_per_layer);
+
+    int max_slot = -1;
+    for (const auto& [ws_id, slot] : pinned_positions) {
+        if (slot > max_slot)
+            max_slot = slot;
+    }
+    const int needed_by_count = (int)(workspace_count + ws_per_layer - 1) / ws_per_layer;
+    const int needed_by_pins = (max_slot >= 0) ? (max_slot / ws_per_layer + 1) : needed_by_count;
+    const int needed_layers = std::max(1, needed_by_pins);
+
     return std::max(configured_layers, needed_layers);
 }
 
@@ -226,6 +235,9 @@ void HTLayoutGrid::on_hide(CallbackFun on_complete) {
 
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
+        return;
+
+    if (monitor->m_activeWorkspace == nullptr)
         return;
 
     layer = get_workspace_layer(monitor->m_activeWorkspace->m_id);
@@ -415,6 +427,12 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         if (ws_to_slot.contains(workspace->m_id))
             continue;
 
+        auto pin_it = pinned_positions.find(workspace->m_id);
+        if (pin_it != pinned_positions.end()) {
+            // Skip workspaces pinned to other layers
+            continue;
+        }
+
         while (next_free < layer_end && slot_occupied[next_free - layer_start])
             ++next_free;
 
@@ -425,6 +443,7 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         ws_to_slot[workspace->m_id] = next_free;
         ++next_free;
     }
+
 
     for (const auto& [ws_id, slot] : ws_to_slot) {
         int local_i = slot - layer_start;

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -48,6 +48,40 @@ std::string HTLayoutGrid::layout_name() {
     return "grid";
 }
 
+void HTLayoutGrid::pin_workspace_to_slot(WORKSPACEID ws_id, int slot) {
+    pinned_positions[ws_id] = slot;
+}
+
+void HTLayoutGrid::unpin_workspace(WORKSPACEID ws_id) {
+    pinned_positions.erase(ws_id);
+}
+
+std::pair<int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) {
+    const PHLMONITOR monitor = get_monitor();
+    if (monitor == nullptr)
+        return {-1, -1};
+
+    if (!monitor->logicalBox().containsPoint(pos))
+        return {-1, -1};
+
+    build_overview_layout(HT_VIEW_ANIMATING);
+
+    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+
+    Vector2D rel = (pos - monitor->m_position) * monitor->m_scale;
+
+    for (int y = 0; y < ROWS; y++) {
+        for (int x = 0; x < COLS; x++) {
+            CBox box = calculate_ws_box(x, y, HT_VIEW_ANIMATING);
+            if (!box.empty() && box.containsPoint(rel))
+                return {x, y};
+        }
+    }
+
+    return {-1, -1};
+}
+
 int HTLayoutGrid::get_effective_layer_count(size_t workspace_count) {
     const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
@@ -59,6 +93,14 @@ int HTLayoutGrid::get_effective_layer_count(size_t workspace_count) {
 }
 
 int HTLayoutGrid::get_workspace_layer(WORKSPACEID workspace_id) {
+    auto pin_it = pinned_positions.find(workspace_id);
+    if (pin_it != pinned_positions.end()) {
+        const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+        const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+        const int ws_per_layer = std::max(1, ROWS * COLS);
+        return pin_it->second / ws_per_layer;
+    }
+
     const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
     const int ws_per_layer = std::max(1, ROWS * COLS);
@@ -68,6 +110,7 @@ int HTLayoutGrid::get_workspace_layer(WORKSPACEID workspace_id) {
         if (workspaces[i] != nullptr && workspaces[i]->m_id == workspace_id)
             return (int)i / ws_per_layer;
     }
+
     return layer;
 }
 
@@ -337,22 +380,66 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     overview_layout.clear();
 
-    const size_t start = layer * ws_per_layer;
-    const size_t end = std::min(start + ws_per_layer, workspaces.size());
-    for (size_t i = start; i < end; i++) {
-        const PHLWORKSPACE workspace = workspaces[i];
+    for (auto it = pinned_positions.begin(); it != pinned_positions.end(); ) {
+        if (g_pCompositor->getWorkspaceByID(it->first) == nullptr)
+            it = pinned_positions.erase(it);
+        else
+            ++it;
+    }
+
+    const int layer_start = layer * ws_per_layer;
+    const int layer_end = layer_start + ws_per_layer;
+
+    std::vector<bool> slot_occupied(ws_per_layer, false);
+    std::unordered_map<WORKSPACEID, int> ws_to_slot;
+
+    for (PHLWORKSPACE workspace : workspaces) {
         if (workspace == nullptr)
             continue;
 
-        const int local_i = (int)(i - start);
-        const int x = local_i % COLS;
-        const int y = local_i / COLS;
+        auto pin_it = pinned_positions.find(workspace->m_id);
+        if (pin_it != pinned_positions.end()) {
+            int slot = pin_it->second;
+            if (slot >= layer_start && slot < layer_end) {
+                int local_i = slot - layer_start;
+                slot_occupied[local_i] = true;
+                ws_to_slot[workspace->m_id] = slot;
+            }
+        }
+    }
+
+    int next_free = layer_start;
+    for (PHLWORKSPACE workspace : workspaces) {
+        if (workspace == nullptr)
+            continue;
+        if (ws_to_slot.contains(workspace->m_id))
+            continue;
+
+        while (next_free < layer_end && slot_occupied[next_free - layer_start])
+            ++next_free;
+
+        if (next_free >= layer_end)
+            break;
+
+        slot_occupied[next_free - layer_start] = true;
+        ws_to_slot[workspace->m_id] = next_free;
+        ++next_free;
+    }
+
+    for (const auto& [ws_id, slot] : ws_to_slot) {
+        int local_i = slot - layer_start;
+        int x = local_i % COLS;
+        int y = local_i / COLS;
+        PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(ws_id);
+        if (workspace == nullptr)
+            continue;
+
         const CBox ws_box = calculate_ws_box(x, y, stage);
-        overview_layout[workspace->m_id] = HTWorkspace {
+        overview_layout[ws_id] = HTWorkspace {
             x,
             y,
             ws_box,
-            workspace->m_id,
+            ws_id,
             workspace->m_name,
             monitor->m_id,
         };

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -337,24 +337,48 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     overview_layout.clear();
 
+    const size_t visible_slots = (size_t)ws_per_layer;
     const size_t start = layer * ws_per_layer;
-    const size_t end = std::min(start + ws_per_layer, workspaces.size());
-    for (size_t i = start; i < end; i++) {
-        const PHLWORKSPACE workspace = workspaces[i];
-        if (workspace == nullptr)
-            continue;
+    const size_t placeholders_needed = start + visible_slots > workspaces.size()
+        ? start + visible_slots - workspaces.size()
+        : 0;
+    const std::vector<WORKSPACEID> placeholder_ids = get_available_workspace_ids(placeholders_needed);
 
-        const int local_i = (int)(i - start);
+    for (size_t local_i = 0; local_i < visible_slots; local_i++) {
+        const size_t workspace_i = start + local_i;
         const int x = local_i % COLS;
         const int y = local_i / COLS;
         const CBox ws_box = calculate_ws_box(x, y, stage);
-        overview_layout[workspace->m_id] = HTWorkspace {
+
+        if (workspace_i < workspaces.size()) {
+            const PHLWORKSPACE workspace = workspaces[workspace_i];
+            if (workspace == nullptr)
+                continue;
+            overview_layout[workspace->m_id] = HTWorkspace {
+                x,
+                y,
+                ws_box,
+                workspace->m_id,
+                workspace->m_name,
+                monitor->m_id,
+                false,
+            };
+            continue;
+        }
+
+        const size_t placeholder_i = workspace_i - workspaces.size();
+        if (placeholder_i >= placeholder_ids.size())
+            continue;
+
+        const WORKSPACEID placeholder_id = placeholder_ids[placeholder_i];
+        overview_layout[placeholder_id] = HTWorkspace {
             x,
             y,
             ws_box,
-            workspace->m_id,
-            workspace->m_name,
+            placeholder_id,
+            std::to_string(placeholder_id),
             monitor->m_id,
+            true,
         };
     }
 }

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -19,11 +19,8 @@
 #include <hyprutils/utils/ScopeGuard.hpp>
 
 #include "../config.hpp"
-#include "../globals.hpp"
 #include "../overview.hpp"
-#include "../render.hpp"
 #include "../types.hpp"
-#include "src/layout/target/Target.hpp"
 
 using Hyprutils::Utils::CScopeGuard;
 
@@ -48,9 +45,41 @@ std::string HTLayoutGrid::layout_name() {
     return "grid";
 }
 
+HTLayoutGrid::HTGridCell* HTLayoutGrid::cell_at(int target_layer, int y, int x) {
+    if (target_layer < 0 || target_layer >= (int)grid_cells.size())
+        return nullptr;
+    if (y < 0 || y >= (int)grid_cells[target_layer].size())
+        return nullptr;
+    if (x < 0 || x >= (int)grid_cells[target_layer][y].size())
+        return nullptr;
+    return &grid_cells[target_layer][y][x];
+}
+
+const HTLayoutGrid::HTGridCell* HTLayoutGrid::cell_at(int target_layer, int y, int x) const {
+    if (target_layer < 0 || target_layer >= (int)grid_cells.size())
+        return nullptr;
+    if (y < 0 || y >= (int)grid_cells[target_layer].size())
+        return nullptr;
+    if (x < 0 || x >= (int)grid_cells[target_layer][y].size())
+        return nullptr;
+    return &grid_cells[target_layer][y][x];
+}
+
+HTLayoutGrid::HTGridCell* HTLayoutGrid::find_cell(WORKSPACEID ws_id) {
+    for (auto& layer_cells : grid_cells) {
+        for (auto& row : layer_cells) {
+            for (auto& cell : row) {
+                if (cell.ws_id == ws_id)
+                    return &cell;
+            }
+        }
+    }
+    return nullptr;
+}
+
 void HTLayoutGrid::pin_workspace_to_slot(WORKSPACEID ws_id, int slot) {
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
     const int ws_per_layer = std::max(1, ROWS * COLS);
 
     const int target_layer = slot / ws_per_layer;
@@ -61,7 +90,6 @@ void HTLayoutGrid::pin_workspace_to_slot(WORKSPACEID ws_id, int slot) {
     if (target_y < 0 || target_y >= ROWS || target_x < 0 || target_x >= COLS)
         return;
 
-    // Grow grid so the requested layer exists (resize default-initializes new cells)
     if (target_layer >= (int)grid_cells.size()) {
         grid_cells.resize(target_layer + 1);
         for (int l = 0; l <= target_layer; l++) {
@@ -71,34 +99,21 @@ void HTLayoutGrid::pin_workspace_to_slot(WORKSPACEID ws_id, int slot) {
         }
     }
 
-    // Clear previous pin for this workspace anywhere in the grid
-    for (auto& layer : grid_cells) {
-        for (auto& row : layer) {
-            for (auto& cell : row) {
-                if (cell.ws_id == ws_id) {
-                    cell.ws_id = WORKSPACE_INVALID;
-                    cell.occupied = false;
-                    cell.is_pinned = false;
-                }
-            }
-        }
+    if (HTGridCell* cell = find_cell(ws_id)) {
+        cell->ws_id = WORKSPACE_INVALID;
+        cell->occupied = false;
+        cell->is_pinned = false;
     }
 
-    auto& cell = grid_cells[target_layer][target_y][target_x];
+    auto& cell = *cell_at(target_layer, target_y, target_x);
     cell.ws_id = ws_id;
     cell.occupied = true;
     cell.is_pinned = true;
 }
 
 void HTLayoutGrid::unpin_workspace(WORKSPACEID ws_id) {
-    for (auto& layer : grid_cells) {
-        for (auto& row : layer) {
-            for (auto& cell : row) {
-                if (cell.ws_id == ws_id)
-                    cell.is_pinned = false;
-            }
-        }
-    }
+    if (HTGridCell* cell = find_cell(ws_id))
+        cell->is_pinned = false;
 }
 
 std::tuple<int, int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) {
@@ -111,8 +126,8 @@ std::tuple<int, int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) 
 
     build_overview_layout(HT_VIEW_ANIMATING);
 
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
 
     Vector2D rel = (pos - monitor->m_position) * monitor->m_scale;
 
@@ -128,9 +143,9 @@ std::tuple<int, int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) 
 }
 
 int HTLayoutGrid::get_effective_layer_count(size_t workspace_count) {
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-    const int LAYERS = HTConfig::value<Hyprlang::INT>("grid:layers");
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
+    const int LAYERS = HTConfig::value("grid:layers");
     const int ws_per_layer = std::max(1, ROWS * COLS);
     const int configured_layers = std::max(1, LAYERS);
 
@@ -152,7 +167,8 @@ int HTLayoutGrid::get_max_occupied_layer() {
     for (int l = 0; l < (int)grid_cells.size(); l++) {
         for (int y = 0; y < (int)grid_cells[l].size(); y++) {
             for (int x = 0; x < (int)grid_cells[l][y].size(); x++) {
-                if (grid_cells[l][y][x].ws_id != WORKSPACE_INVALID) {
+                const HTGridCell* cell = cell_at(l, y, x);
+                if (cell != nullptr && cell->ws_id != WORKSPACE_INVALID) {
                     max_occupied = std::max(max_occupied, l);
                     break;
                 }
@@ -163,21 +179,19 @@ int HTLayoutGrid::get_max_occupied_layer() {
 }
 
 int HTLayoutGrid::get_workspace_layer(WORKSPACEID workspace_id) {
-    for (int l = 0; l < (int)grid_cells.size(); l++) {
-        for (int y = 0; y < (int)grid_cells[l].size(); y++) {
-            for (int x = 0; x < (int)grid_cells[l][y].size(); x++) {
-                if (grid_cells[l][y][x].ws_id == workspace_id)
-                    return l;
-            }
-        }
-    }
+    if (const HTGridCell* cell = find_cell(workspace_id))
+        for (int l = 0; l < (int)grid_cells.size(); l++)
+            for (int y = 0; y < (int)grid_cells[l].size(); y++)
+                for (int x = 0; x < (int)grid_cells[l][y].size(); x++)
+                    if (cell_at(l, y, x) == cell)
+                        return l;
     return layer;
 }
 
 WORKSPACEID HTLayoutGrid::get_ws_id_in_direction(int x, int y, std::string& direction) {
-    const int LOOP = HTConfig::value<Hyprlang::INT>("grid:loop");
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int LOOP = HTConfig::value("grid:loop");
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
 
     if (direction == "up") {
         y--;
@@ -203,9 +217,9 @@ void HTLayoutGrid::on_move_swipe(Vector2D delta) {
     if (monitor == nullptr)
         return;
 
-    const float MOVE_DISTANCE = HTConfig::value<Hyprlang::FLOAT>("gestures:move_distance");
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const float MOVE_DISTANCE = HTConfig::value_float("gestures:move_distance");
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
     const CBox min_ws = calculate_ws_box(0, 0, HT_VIEW_CLOSED);
     const CBox max_ws = calculate_ws_box(COLS - 1, ROWS - 1, HT_VIEW_CLOSED);
 
@@ -306,7 +320,6 @@ void HTLayoutGrid::on_move(WORKSPACEID old_id, WORKSPACEID new_id, CallbackFun o
             offset->setCallbackOnEnd(on_complete);
     });
 
-    const PHTVIEW par_view = ht_manager->get_view_from_id(view_id);
     if (par_view == nullptr || par_view->active)
         return;
 
@@ -383,10 +396,10 @@ CBox HTLayoutGrid::calculate_ws_box(int x, int y, HTViewStage stage) {
     if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
         return {};
 
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-    const int GAPS_USE_ASPECT_RATIO = HTConfig::value<Hyprlang::INT>("grid:gaps_use_aspect_ratio");
-    const float GAP_SIZE = HTConfig::value<Hyprlang::FLOAT>("gap_size") * monitor->m_scale;
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
+    const int GAPS_USE_ASPECT_RATIO = HTConfig::value("grid:gaps_use_aspect_ratio");
+    const float GAP_SIZE = HTConfig::value_float("gap_size") * monitor->m_scale;
     const Vector2D gaps = {
         GAP_SIZE,
         GAPS_USE_ASPECT_RATIO
@@ -430,8 +443,8 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
     if (monitor == nullptr)
         return;
 
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
     std::vector<PHLWORKSPACE> workspaces = get_monitor_workspaces();
     std::ranges::sort(workspaces, [](const PHLWORKSPACE& lhs, const PHLWORKSPACE& rhs) {
         if (lhs == nullptr)
@@ -445,8 +458,6 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     overview_layout.clear();
 
-    // Resize grid_cells to match effective layers (only new cells get default-initialized
-    // by resize; existing cells preserve their ws_id / is_pinned state)
     grid_cells.resize(effective_layers);
     for (int l = 0; l < effective_layers; l++) {
         grid_cells[l].resize(ROWS);
@@ -455,53 +466,38 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         }
     }
 
-    // Clean up stale workspace references; do NOT reset occupied/pinned state
-    // for cells whose workspace is still valid, otherwise pin_workspace_to_slot
-    // results survive the next frame.
     for (int l = 0; l < effective_layers; l++) {
         for (int y = 0; y < (int)grid_cells[l].size(); y++) {
             for (int x = 0; x < (int)grid_cells[l][y].size(); x++) {
-                auto& cell = grid_cells[l][y][x];
-                if (cell.ws_id != WORKSPACE_INVALID) {
-                    const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(cell.ws_id);
+                HTGridCell* cell = cell_at(l, y, x);
+                if (cell != nullptr && cell->ws_id != WORKSPACE_INVALID) {
+                    const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(cell->ws_id);
                     if (!is_monitor_workspace(workspace)) {
-                        cell.ws_id = WORKSPACE_INVALID;
-                        cell.occupied = false;
-                        cell.is_pinned = false;
+                        cell->ws_id = WORKSPACE_INVALID;
+                        cell->occupied = false;
+                        cell->is_pinned = false;
                     }
                 }
             }
         }
     }
 
-    // Place every workspace that belongs to this monitor: if it already has a
-    // cell in the grid (from a previous frame or a pin), keep it there; otherwise
-    // fill the first truly empty cell.
     for (PHLWORKSPACE workspace : workspaces) {
         if (workspace == nullptr)
             continue;
 
-        bool already_placed = false;
-        for (int l = 0; l < effective_layers && !already_placed; l++) {
-            for (int y = 0; y < (int)grid_cells[l].size() && !already_placed; y++) {
-                for (int x = 0; x < (int)grid_cells[l][y].size() && !already_placed; x++) {
-                    if (grid_cells[l][y][x].ws_id == workspace->m_id)
-                        already_placed = true;
-                }
-            }
-        }
-        if (already_placed)
+        if (find_cell(workspace->m_id) != nullptr)
             continue;
 
         bool placed = false;
         for (int l = 0; l < effective_layers && !placed; l++) {
             for (int y = 0; y < ROWS && !placed; y++) {
                 for (int x = 0; x < COLS && !placed; x++) {
-                    auto& cell = grid_cells[l][y][x];
-                    if (cell.ws_id == WORKSPACE_INVALID) {
-                        cell.ws_id = workspace->m_id;
-                        cell.occupied = true;
-                        cell.is_pinned = false;
+                    HTGridCell* cell = cell_at(l, y, x);
+                    if (cell != nullptr && cell->ws_id == WORKSPACE_INVALID) {
+                        cell->ws_id = workspace->m_id;
+                        cell->occupied = true;
+                        cell->is_pinned = false;
                         placed = true;
                     }
                 }
@@ -509,24 +505,23 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         }
     }
 
-    // Populate overview_layout from grid_cells for the current layer
     if (layer >= 0 && layer < effective_layers) {
         for (int y = 0; y < ROWS; y++) {
             for (int x = 0; x < COLS; x++) {
-                const auto& cell = grid_cells[layer][y][x];
-                if (cell.ws_id == WORKSPACE_INVALID)
+                const HTGridCell* cell = cell_at(layer, y, x);
+                if (cell == nullptr || cell->ws_id == WORKSPACE_INVALID)
                     continue;
 
-                PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(cell.ws_id);
+                PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(cell->ws_id);
                 if (workspace == nullptr)
                     continue;
 
                 const CBox ws_box = calculate_ws_box(x, y, stage);
-                overview_layout[cell.ws_id] = HTWorkspace {
+                overview_layout[cell->ws_id] = HTWorkspace {
                     x,
                     y,
                     ws_box,
-                    cell.ws_id,
+                    cell->ws_id,
                     workspace->m_name,
                     monitor->m_id,
                 };
@@ -546,23 +541,16 @@ void HTLayoutGrid::render() {
     if (monitor == nullptr)
         return;
 
-    static auto PACTIVECOL = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.active_border");
-    static auto PINACTIVECOL = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.inactive_border");
-
-    auto* const ACTIVECOL = (CGradientValueData*)(PACTIVECOL.ptr())->getData();
-    auto* const INACTIVECOL = (CGradientValueData*)(PINACTIVECOL.ptr())->getData();
-
-    const float BORDERSIZE = HTConfig::value<Hyprlang::FLOAT>("border_size");
-
-    const auto time = Time::steadyNow();
-
+    const int bg_color = HTConfig::value("bg_color");
+    const float border_size = cached_border_size;
+    const float scale_value = scale->value();
 
     g_pHyprRenderer->damageMonitor(monitor);
     g_pHyprOpenGL->m_renderData.pCurrentMonData->blurFBShouldRender = true;
     CBox monitor_box = {{0, 0}, monitor->m_transformedSize};
 
     CRectPassElement::SRectData data;
-    data.color = CHyprColor {HTConfig::value<Hyprlang::INT>("bg_color")}.stripA();
+    data.color = CHyprColor {bg_color}.stripA();
     data.box = monitor_box;
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(data));
 
@@ -593,8 +581,8 @@ void HTLayoutGrid::render() {
 
     build_overview_layout(HT_VIEW_ANIMATING);
 
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int ROWS = HTConfig::value("grid:rows");
+    const int COLS = HTConfig::value("grid:cols");
     const int effective_layers = grid_cells.size();
 
     if (layer < 0 || layer >= effective_layers)
@@ -603,13 +591,13 @@ void HTLayoutGrid::render() {
     CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
     for (int y = 0; y < ROWS; y++) {
         for (int x = 0; x < COLS; x++) {
-            const auto& cell = grid_cells[layer][y][x];
-            const bool has_ws = cell.ws_id != WORKSPACE_INVALID;
+            const HTGridCell* cell = cell_at(layer, y, x);
+            const bool has_ws = cell != nullptr && cell->ws_id != WORKSPACE_INVALID;
 
             CBox ws_box;
             WORKSPACEID ws_id = WORKSPACE_INVALID;
             if (has_ws) {
-                ws_id = cell.ws_id;
+                ws_id = cell->ws_id;
                 const auto& ws_layout = overview_layout[ws_id];
                 ws_box = ws_layout.box;
             } else {
@@ -619,7 +607,7 @@ void HTLayoutGrid::render() {
             if (ws_box.width < 0.01 || ws_box.height < 0.01)
                 continue;
 
-            CBox render_box = {{ws_box.pos() / scale->value()}, ws_box.size()};
+            CBox render_box = {{ws_box.pos() / scale_value}, ws_box.size()};
             if (monitor->m_transform % 2 == 1)
                 std::swap(render_box.w, render_box.h);
 
@@ -627,56 +615,18 @@ void HTLayoutGrid::render() {
                 continue;
 
             CBox global_box = {ws_box.pos() + monitor->m_position, ws_box.size()};
-            if (global_box.expand(BORDERSIZE).intersection(global_mon_box).empty())
+            if (global_box.expand(border_size).intersection(global_mon_box).empty())
                 continue;
 
-            const CGradientValueData border_col =
-                (has_ws && start_workspace->m_id == ws_id) ? *ACTIVECOL : *INACTIVECOL;
-            CBox border_box = ws_box;
-
-            CBorderPassElement::SBorderData data;
-            data.box = border_box;
-            data.grad1 = border_col;
-            data.borderSize = BORDERSIZE;
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
+            render_border(ws_box, has_ws && start_workspace->m_id == ws_id);
 
             if (has_ws) {
                 const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
 
-                if (workspace != nullptr) {
-                    monitor->m_activeWorkspace = workspace;
-                    g_pDesktopAnimationManager->startAnimation(
-                        workspace,
-                        CDesktopAnimationManager::ANIMATION_TYPE_IN,
-                        false,
-                        true
-                    );
-                    workspace->m_visible = true;
-
-                    ((render_workspace_t)(render_workspace_hook->m_original))(
-                        g_pHyprRenderer.get(),
-                        monitor,
-                        workspace,
-                        time,
-                        render_box
-                    );
-
-                    g_pDesktopAnimationManager->startAnimation(
-                        workspace,
-                        CDesktopAnimationManager::ANIMATION_TYPE_OUT,
-                        false,
-                        true
-                    );
-                    workspace->m_visible = false;
-                }
+                if (workspace != nullptr)
+                    render_workspace(workspace, render_box, false);
             } else {
-                ((render_workspace_t)(render_workspace_hook->m_original))(
-                    g_pHyprRenderer.get(),
-                    monitor,
-                    nullptr,
-                    time,
-                    render_box
-                );
+                render_workspace(nullptr, render_box, false);
             }
         }
     }
@@ -694,45 +644,14 @@ void HTLayoutGrid::render() {
     if (start_workspace != nullptr && active_it != overview_layout.end()) {
         CBox ws_box = active_it->second.box;
         if (ws_box.width > 0.01 && ws_box.height > 0.01) {
-            CBox render_box = {{ws_box.pos() / scale->value()}, ws_box.size()};
+            CBox render_box = {{ws_box.pos() / scale_value}, ws_box.size()};
             if (monitor->m_transform % 2 == 1)
                 std::swap(render_box.w, render_box.h);
 
-            const CGradientValueData border_col =
-                monitor->m_activeWorkspace->m_id == start_workspace->m_id ? *ACTIVECOL
-                                                                          : *INACTIVECOL;
-            CBox border_box = ws_box;
-
-            CBorderPassElement::SBorderData data;
-            data.box = border_box;
-            data.grad1 = border_col;
-            data.borderSize = BORDERSIZE;
-            g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
-
-            ((render_workspace_t)(render_workspace_hook->m_original))(
-                g_pHyprRenderer.get(),
-                monitor,
-                start_workspace,
-                time,
-                render_box
-            );
+            render_border(ws_box, monitor->m_activeWorkspace->m_id == start_workspace->m_id);
+            render_workspace(start_workspace, render_box, true);
         }
     }
 
-    const PHTVIEW cursor_view = ht_manager->get_view_from_cursor();
-    if (cursor_view == nullptr)
-        return;
-    const SP<Layout::ITarget> target = g_layoutManager->dragController()->target();
-    if (target == nullptr)
-        return;
-    const PHLWINDOW dragged_window = target->window();
-    if (dragged_window == nullptr)
-        return;
-    const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
-    const CBox window_box = dragged_window->getWindowMainSurfaceBox()
-                                .translate(-mouse_coords)
-                                .scale(cursor_view->layout->drag_window_scale())
-                                .translate(mouse_coords);
-    if (!window_box.intersection(monitor->logicalBox()).empty())
-        render_window_at_box(dragged_window, monitor, time, window_box);
+    render_dragged_window();
 }

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -451,7 +451,7 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     for (auto it = pinned_positions.begin(); it != pinned_positions.end(); ) {
         const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(it->first);
-        if (!is_monitor_workspace(workspace))
+        if (workspace == nullptr || workspace->inert() || workspace->m_isSpecialWorkspace)
             it = pinned_positions.erase(it);
         else
             ++it;
@@ -459,7 +459,24 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
 
     const int total_slots = effective_layers * ws_per_layer;
     std::vector<WORKSPACEID> slot_to_ws(total_slots, WORKSPACE_INVALID);
+    std::vector<bool> slot_occupied(total_slots, false);
     std::unordered_map<WORKSPACEID, int> ws_to_slot;
+
+    std::vector<std::pair<WORKSPACEID, int>> pinned_slots;
+    pinned_slots.reserve(pinned_positions.size());
+    for (const auto& [ws_id, slot] : pinned_positions)
+        pinned_slots.emplace_back(ws_id, slot);
+
+    std::ranges::sort(pinned_slots, [](const auto& lhs, const auto& rhs) {
+        if (lhs.second != rhs.second)
+            return lhs.second < rhs.second;
+        return lhs.first < rhs.first;
+    });
+
+    for (const auto& [ws_id, slot] : pinned_slots) {
+        if (slot >= 0 && slot < total_slots && !slot_occupied[slot])
+            slot_occupied[slot] = true;
+    }
 
     for (PHLWORKSPACE workspace : workspaces) {
         if (workspace == nullptr)
@@ -484,13 +501,14 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
         if (ws_to_slot.contains(workspace->m_id))
             continue;
 
-        while (next_free < total_slots && slot_to_ws[next_free] != WORKSPACE_INVALID)
+        while (next_free < total_slots && slot_occupied[next_free])
             ++next_free;
 
         if (next_free >= total_slots)
             break;
 
         slot_to_ws[next_free] = workspace->m_id;
+        slot_occupied[next_free] = true;
         ws_to_slot[workspace->m_id] = next_free;
         pinned_positions[workspace->m_id] = next_free;
         ++next_free;

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -631,8 +631,6 @@ void HTLayoutGrid::render() {
         }
     }
 
-    // CScopeGuard restore_workspace handles the final cleanup above
-
     const auto active_it = overview_layout.find(start_workspace->m_id);
     if (start_workspace != nullptr && active_it != overview_layout.end()) {
         CBox ws_box = active_it->second.box;

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -570,6 +570,19 @@ void HTLayoutGrid::render() {
     if (start_workspace == nullptr)
         return;
 
+    CScopeGuard restore_workspace([&monitor, &start_workspace] {
+        if (monitor == nullptr || start_workspace == nullptr)
+            return;
+        monitor->m_activeWorkspace = start_workspace;
+        g_pDesktopAnimationManager->startAnimation(
+            start_workspace,
+            CDesktopAnimationManager::ANIMATION_TYPE_IN,
+            false,
+            true
+        );
+        start_workspace->m_visible = true;
+    });
+
     g_pDesktopAnimationManager->startAnimation(
         start_workspace,
         CDesktopAnimationManager::ANIMATION_TYPE_OUT,

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -406,73 +406,103 @@ void HTLayoutGrid::render() {
 
     build_overview_layout(HT_VIEW_ANIMATING);
 
-    CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
+    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+
+    std::unordered_map<int, WORKSPACEID> grid_to_ws;
     for (const auto& [ws_id, ws_layout] : overview_layout) {
-        // Skip if the box is empty
-        if (ws_layout.box.width < 0.01 || ws_layout.box.height < 0.01)
-            continue;
+        grid_to_ws[ws_layout.y * COLS + ws_layout.x] = ws_id;
+    }
 
-        // Could be nullptr, in which we render only layers
-        const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
+    CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
+    for (int y = 0; y < ROWS; y++) {
+        for (int x = 0; x < COLS; x++) {
+            const int grid_key = y * COLS + x;
+            const bool has_ws = grid_to_ws.contains(grid_key);
 
-        // renderModif translation used by renderWorkspace is weird so need
-        // to scale the translation up as well. Geometry is also calculated from pixel size and not transformed size??
-        CBox render_box = {{ws_layout.box.pos() / scale->value()}, ws_layout.box.size()};
-        if (monitor->m_transform % 2 == 1)
-            std::swap(render_box.w, render_box.h);
+            CBox ws_box;
+            WORKSPACEID ws_id = WORKSPACE_INVALID;
+            if (has_ws) {
+                ws_id = grid_to_ws[grid_key];
+                const auto& ws_layout = overview_layout[ws_id];
+                ws_box = ws_layout.box;
+            } else {
+                ws_box = calculate_ws_box(x, y, HT_VIEW_ANIMATING);
+            }
 
-        // render active one last
-        if (workspace == start_workspace && start_workspace != nullptr)
-            continue;
+            if (ws_box.width < 0.01 || ws_box.height < 0.01)
+                continue;
 
-        CBox global_box = {ws_layout.box.pos() + monitor->m_position, ws_layout.box.size()};
-        if (global_box.expand(BORDERSIZE).intersection(global_mon_box).empty())
-            continue;
+            // renderModif translation used by renderWorkspace is weird so need
+            // to scale the translation up as well. Geometry is also calculated from pixel size and not transformed size??
+            CBox render_box = {{ws_box.pos() / scale->value()}, ws_box.size()};
+            if (monitor->m_transform % 2 == 1)
+                std::swap(render_box.w, render_box.h);
 
-        const CGradientValueData border_col =
-            start_workspace->m_id == ws_id ? *ACTIVECOL : *INACTIVECOL;
-        CBox border_box = ws_layout.box;
+            // render active one last
+            if (has_ws && ws_id == start_workspace->m_id && start_workspace != nullptr)
+                continue;
 
-        CBorderPassElement::SBorderData data;
-        data.box = border_box;
-        data.grad1 = border_col;
-        data.borderSize = BORDERSIZE;
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
+            CBox global_box = {ws_box.pos() + monitor->m_position, ws_box.size()};
+            if (global_box.expand(BORDERSIZE).intersection(global_mon_box).empty())
+                continue;
 
-        if (workspace != nullptr) {
-            monitor->m_activeWorkspace = workspace;
-            g_pDesktopAnimationManager->startAnimation(
-                workspace,
-                CDesktopAnimationManager::ANIMATION_TYPE_IN,
-                false,
-                true
-            );
-            workspace->m_visible = true;
+            const CGradientValueData border_col =
+                (has_ws && start_workspace->m_id == ws_id) ? *ACTIVECOL : *INACTIVECOL;
+            CBox border_box = ws_box;
 
-            ((render_workspace_t)(render_workspace_hook->m_original))(
-                g_pHyprRenderer.get(),
-                monitor,
-                workspace,
-                time,
-                render_box
-            );
+            CBorderPassElement::SBorderData data;
+            data.box = border_box;
+            data.grad1 = border_col;
+            data.borderSize = BORDERSIZE;
+            g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
 
-            g_pDesktopAnimationManager->startAnimation(
-                workspace,
-                CDesktopAnimationManager::ANIMATION_TYPE_OUT,
-                false,
-                true
-            );
-            workspace->m_visible = false;
-        } else {
-            // If pWorkspace is null, then just render the layers
-            ((render_workspace_t)(render_workspace_hook->m_original))(
-                g_pHyprRenderer.get(),
-                monitor,
-                workspace,
-                time,
-                render_box
-            );
+            if (has_ws) {
+                const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
+
+                if (workspace != nullptr) {
+                    monitor->m_activeWorkspace = workspace;
+                    g_pDesktopAnimationManager->startAnimation(
+                        workspace,
+                        CDesktopAnimationManager::ANIMATION_TYPE_IN,
+                        false,
+                        true
+                    );
+                    workspace->m_visible = true;
+
+                    ((render_workspace_t)(render_workspace_hook->m_original))(
+                        g_pHyprRenderer.get(),
+                        monitor,
+                        workspace,
+                        time,
+                        render_box
+                    );
+
+                    g_pDesktopAnimationManager->startAnimation(
+                        workspace,
+                        CDesktopAnimationManager::ANIMATION_TYPE_OUT,
+                        false,
+                        true
+                    );
+                    workspace->m_visible = false;
+                } else {
+                    ((render_workspace_t)(render_workspace_hook->m_original))(
+                        g_pHyprRenderer.get(),
+                        monitor,
+                        workspace,
+                        time,
+                        render_box
+                    );
+                }
+            } else {
+                ((render_workspace_t)(render_workspace_hook->m_original))(
+                    g_pHyprRenderer.get(),
+                    monitor,
+                    nullptr,
+                    time,
+                    render_box
+                );
+            }
         }
     }
 

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -554,30 +554,30 @@ void HTLayoutGrid::render() {
     data.box = monitor_box;
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(data));
 
-    const PHLWORKSPACE start_workspace = monitor->m_activeWorkspace;
-    if (start_workspace == nullptr)
+    const PHLWORKSPACE pre_overview_ws = monitor->m_activeWorkspace;
+    if (pre_overview_ws == nullptr)
         return;
 
-    CScopeGuard restore_workspace([&monitor, &start_workspace] {
-        if (monitor == nullptr || start_workspace == nullptr)
+    CScopeGuard restore_workspace([&monitor, &pre_overview_ws] {
+        if (monitor == nullptr || pre_overview_ws == nullptr)
             return;
-        monitor->m_activeWorkspace = start_workspace;
+        monitor->m_activeWorkspace = pre_overview_ws;
         g_pDesktopAnimationManager->startAnimation(
-            start_workspace,
+            pre_overview_ws,
             CDesktopAnimationManager::ANIMATION_TYPE_IN,
             false,
             true
         );
-        start_workspace->m_visible = true;
+        pre_overview_ws->m_visible = true;
     });
 
     g_pDesktopAnimationManager->startAnimation(
-        start_workspace,
+        pre_overview_ws,
         CDesktopAnimationManager::ANIMATION_TYPE_OUT,
         false,
         true
     );
-    start_workspace->m_visible = false;
+    pre_overview_ws->m_visible = false;
 
     build_overview_layout(HT_VIEW_ANIMATING);
 
@@ -588,7 +588,14 @@ void HTLayoutGrid::render() {
     if (layer < 0 || layer >= effective_layers)
         return;
 
+    // Determine the workspace currently hovered by the cursor
+    const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
+    const WORKSPACEID hovered_ws_id = get_ws_id_from_global(mouse_coords);
+
     CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
+    PHLWORKSPACE active_ws = nullptr;
+    CBox active_box;
+    CBox active_render_box;
     for (int y = 0; y < ROWS; y++) {
         for (int x = 0; x < COLS; x++) {
             const HTGridCell* cell = cell_at(layer, y, x);
@@ -611,18 +618,21 @@ void HTLayoutGrid::render() {
             if (monitor->m_transform % 2 == 1)
                 std::swap(render_box.w, render_box.h);
 
-            if (has_ws && ws_id == start_workspace->m_id && start_workspace != nullptr)
-                continue;
-
             CBox global_box = {ws_box.pos() + monitor->m_position, ws_box.size()};
             if (global_box.expand(border_size).intersection(global_mon_box).empty())
                 continue;
 
-            render_border(ws_box, has_ws && start_workspace->m_id == ws_id);
+            if (has_ws && ws_id == hovered_ws_id) {
+                active_ws = get_workspace_from_layout(ws_id);
+                active_box = ws_box;
+                active_render_box = render_box;
+                continue;
+            }
+
+            render_border(ws_box, false);
 
             if (has_ws) {
                 const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
-
                 if (workspace != nullptr)
                     render_workspace(workspace, render_box, false);
             } else {
@@ -631,16 +641,22 @@ void HTLayoutGrid::render() {
         }
     }
 
-    const auto active_it = overview_layout.find(start_workspace->m_id);
-    if (start_workspace != nullptr && active_it != overview_layout.end()) {
-        CBox ws_box = active_it->second.box;
-        if (ws_box.width > 0.01 && ws_box.height > 0.01) {
-            CBox render_box = {{ws_box.pos() / scale_value}, ws_box.size()};
-            if (monitor->m_transform % 2 == 1)
-                std::swap(render_box.w, render_box.h);
-
-            render_border(ws_box, monitor->m_activeWorkspace->m_id == start_workspace->m_id);
-            render_workspace(start_workspace, render_box, true);
+    // Render the hovered workspace as active (blue border, no OUT animation).
+    // If nothing is hovered, fall back to the pre-overview workspace.
+    if (active_ws != nullptr) {
+        render_border(active_box, true);
+        render_workspace(active_ws, active_render_box, true);
+    } else if (pre_overview_ws != nullptr) {
+        const auto active_it = overview_layout.find(pre_overview_ws->m_id);
+        if (active_it != overview_layout.end()) {
+            CBox ws_box = active_it->second.box;
+            if (ws_box.width > 0.01 && ws_box.height > 0.01) {
+                CBox render_box = {{ws_box.pos() / scale_value}, ws_box.size()};
+                if (monitor->m_transform % 2 == 1)
+                    std::swap(render_box.w, render_box.h);
+                render_border(ws_box, true);
+                render_workspace(pre_overview_ws, render_box, true);
+            }
         }
     }
 

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -549,6 +549,8 @@ void HTLayoutGrid::render() {
     g_pHyprOpenGL->m_renderData.pCurrentMonData->blurFBShouldRender = true;
     CBox monitor_box = {{0, 0}, monitor->m_transformedSize};
 
+    const auto time = Time::steadyNow();
+
     CRectPassElement::SRectData data;
     data.color = CHyprColor {bg_color}.stripA();
     data.box = monitor_box;
@@ -588,14 +590,7 @@ void HTLayoutGrid::render() {
     if (layer < 0 || layer >= effective_layers)
         return;
 
-    // Determine the workspace currently hovered by the cursor
-    const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
-    const WORKSPACEID hovered_ws_id = get_ws_id_from_global(mouse_coords);
-
     CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
-    PHLWORKSPACE active_ws = nullptr;
-    CBox active_box;
-    CBox active_render_box;
     for (int y = 0; y < ROWS; y++) {
         for (int x = 0; x < COLS; x++) {
             const HTGridCell* cell = cell_at(layer, y, x);
@@ -618,45 +613,66 @@ void HTLayoutGrid::render() {
             if (monitor->m_transform % 2 == 1)
                 std::swap(render_box.w, render_box.h);
 
+            if (has_ws && ws_id == pre_overview_ws->m_id && pre_overview_ws != nullptr)
+                continue;
+
             CBox global_box = {ws_box.pos() + monitor->m_position, ws_box.size()};
             if (global_box.expand(border_size).intersection(global_mon_box).empty())
                 continue;
 
-            if (has_ws && ws_id == hovered_ws_id) {
-                active_ws = get_workspace_from_layout(ws_id);
-                active_box = ws_box;
-                active_render_box = render_box;
-                continue;
-            }
-
-            render_border(ws_box, false);
-
             if (has_ws) {
                 const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
-                if (workspace != nullptr)
-                    render_workspace(workspace, render_box, false);
+
+                if (workspace != nullptr) {
+                    monitor->m_activeWorkspace = workspace;
+                    g_pDesktopAnimationManager->startAnimation(
+                        workspace,
+                        CDesktopAnimationManager::ANIMATION_TYPE_IN,
+                        false,
+                        true
+                    );
+                    workspace->m_visible = true;
+
+                    ((render_workspace_t)(render_workspace_hook->m_original))(
+                        g_pHyprRenderer.get(),
+                        monitor,
+                        workspace,
+                        time,
+                        render_box
+                    );
+
+                    g_pDesktopAnimationManager->startAnimation(
+                        workspace,
+                        CDesktopAnimationManager::ANIMATION_TYPE_OUT,
+                        false,
+                        true
+                    );
+                    workspace->m_visible = false;
+                }
             } else {
-                render_workspace(nullptr, render_box, false);
+                ((render_workspace_t)(render_workspace_hook->m_original))(
+                    g_pHyprRenderer.get(),
+                    monitor,
+                    nullptr,
+                    time,
+                    render_box
+                );
             }
+
+            render_border(ws_box, has_ws && pre_overview_ws->m_id == ws_id);
         }
     }
 
-    // Render the hovered workspace as active (blue border, no OUT animation).
-    // If nothing is hovered, fall back to the pre-overview workspace.
-    if (active_ws != nullptr) {
-        render_border(active_box, true);
-        render_workspace(active_ws, active_render_box, true);
-    } else if (pre_overview_ws != nullptr) {
-        const auto active_it = overview_layout.find(pre_overview_ws->m_id);
-        if (active_it != overview_layout.end()) {
-            CBox ws_box = active_it->second.box;
-            if (ws_box.width > 0.01 && ws_box.height > 0.01) {
-                CBox render_box = {{ws_box.pos() / scale_value}, ws_box.size()};
-                if (monitor->m_transform % 2 == 1)
-                    std::swap(render_box.w, render_box.h);
-                render_border(ws_box, true);
-                render_workspace(pre_overview_ws, render_box, true);
-            }
+    const auto active_it = overview_layout.find(pre_overview_ws->m_id);
+    if (pre_overview_ws != nullptr && active_it != overview_layout.end()) {
+        CBox ws_box = active_it->second.box;
+        if (ws_box.width > 0.01 && ws_box.height > 0.01) {
+            CBox render_box = {{ws_box.pos() / scale_value}, ws_box.size()};
+            if (monitor->m_transform % 2 == 1)
+                std::swap(render_box.w, render_box.h);
+
+            render_workspace(pre_overview_ws, render_box, true);
+            render_border(ws_box, true);
         }
     }
 

--- a/src/layout/grid.cpp
+++ b/src/layout/grid.cpp
@@ -49,18 +49,56 @@ std::string HTLayoutGrid::layout_name() {
 }
 
 void HTLayoutGrid::pin_workspace_to_slot(WORKSPACEID ws_id, int slot) {
-    for (auto it = pinned_positions.begin(); it != pinned_positions.end(); ) {
-        if (it->first != ws_id && it->second == slot)
-            it = pinned_positions.erase(it);
-        else
-            ++it;
+    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int ws_per_layer = std::max(1, ROWS * COLS);
+
+    const int target_layer = slot / ws_per_layer;
+    const int local_slot = slot % ws_per_layer;
+    const int target_y = local_slot / COLS;
+    const int target_x = local_slot % COLS;
+
+    if (target_y < 0 || target_y >= ROWS || target_x < 0 || target_x >= COLS)
+        return;
+
+    // Grow grid so the requested layer exists (resize default-initializes new cells)
+    if (target_layer >= (int)grid_cells.size()) {
+        grid_cells.resize(target_layer + 1);
+        for (int l = 0; l <= target_layer; l++) {
+            grid_cells[l].resize(ROWS);
+            for (int y = 0; y < ROWS; y++)
+                grid_cells[l][y].resize(COLS);
+        }
     }
 
-    pinned_positions[ws_id] = slot;
+    // Clear previous pin for this workspace anywhere in the grid
+    for (auto& layer : grid_cells) {
+        for (auto& row : layer) {
+            for (auto& cell : row) {
+                if (cell.ws_id == ws_id) {
+                    cell.ws_id = WORKSPACE_INVALID;
+                    cell.occupied = false;
+                    cell.is_pinned = false;
+                }
+            }
+        }
+    }
+
+    auto& cell = grid_cells[target_layer][target_y][target_x];
+    cell.ws_id = ws_id;
+    cell.occupied = true;
+    cell.is_pinned = true;
 }
 
 void HTLayoutGrid::unpin_workspace(WORKSPACEID ws_id) {
-    pinned_positions.erase(ws_id);
+    for (auto& layer : grid_cells) {
+        for (auto& row : layer) {
+            for (auto& cell : row) {
+                if (cell.ws_id == ws_id)
+                    cell.is_pinned = false;
+            }
+        }
+    }
 }
 
 std::tuple<int, int, int> HTLayoutGrid::get_grid_cell_from_global(Vector2D pos) {
@@ -96,80 +134,43 @@ int HTLayoutGrid::get_effective_layer_count(size_t workspace_count) {
     const int ws_per_layer = std::max(1, ROWS * COLS);
     const int configured_layers = std::max(1, LAYERS);
 
-    int max_slot = -1;
-    for (const auto& [ws_id, slot] : pinned_positions) {
-        if (slot > max_slot)
-            max_slot = slot;
-    }
     const int needed_by_count = (int)(workspace_count + ws_per_layer - 1) / ws_per_layer;
-    const int needed_by_pins = (max_slot >= 0) ? (max_slot / ws_per_layer + 1) : needed_by_count;
-    const int needed_layers = std::max(1, needed_by_pins);
+    const int needed_layers = std::max(1, needed_by_count);
 
-    return std::max(configured_layers, needed_layers);
+    int max_layer = std::max(configured_layers, needed_layers);
+
+    // If the grid has previously been grown by pin_workspace_to_slot,
+    // keep enough layers so those pins remain addressable.
+    if (!grid_cells.empty())
+        max_layer = std::max(max_layer, get_max_occupied_layer() + 1);
+
+    return max_layer;
+}
+
+int HTLayoutGrid::get_max_occupied_layer() {
+    int max_occupied = 0;
+    for (int l = 0; l < (int)grid_cells.size(); l++) {
+        for (int y = 0; y < (int)grid_cells[l].size(); y++) {
+            for (int x = 0; x < (int)grid_cells[l][y].size(); x++) {
+                if (grid_cells[l][y][x].ws_id != WORKSPACE_INVALID) {
+                    max_occupied = std::max(max_occupied, l);
+                    break;
+                }
+            }
+        }
+    }
+    return max_occupied;
 }
 
 int HTLayoutGrid::get_workspace_layer(WORKSPACEID workspace_id) {
-    auto pin_it = pinned_positions.find(workspace_id);
-    if (pin_it != pinned_positions.end()) {
-        const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-        const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-        const int ws_per_layer = std::max(1, ROWS * COLS);
-        return pin_it->second / ws_per_layer;
-    }
-
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-    const int ws_per_layer = std::max(1, ROWS * COLS);
-    const std::vector<PHLWORKSPACE> workspaces = get_monitor_workspaces();
-    std::vector<WORKSPACEID> workspace_ids;
-    workspace_ids.reserve(workspaces.size());
-
-    for (PHLWORKSPACE workspace : workspaces) {
-        if (workspace != nullptr)
-            workspace_ids.push_back(workspace->m_id);
-    }
-
-    std::ranges::sort(workspace_ids);
-
-    int max_slot = -1;
-    for (const auto& [ws_id, slot] : pinned_positions) {
-        if (g_pCompositor->getWorkspaceByID(ws_id) != nullptr && slot > max_slot)
-            max_slot = slot;
-    }
-
-    const int effective_layers = std::max(get_effective_layer_count(workspace_ids.size()), max_slot / ws_per_layer + 1);
-    std::vector<WORKSPACEID> slot_to_ws(effective_layers * ws_per_layer, WORKSPACE_INVALID);
-
-    for (WORKSPACEID ws_id : workspace_ids) {
-        pin_it = pinned_positions.find(ws_id);
-        if (pin_it == pinned_positions.end())
-            continue;
-
-        if (pin_it->second >= 0 && pin_it->second < (int)slot_to_ws.size()
-            && slot_to_ws[pin_it->second] == WORKSPACE_INVALID) {
-            slot_to_ws[pin_it->second] = ws_id;
+    for (int l = 0; l < (int)grid_cells.size(); l++) {
+        for (int y = 0; y < (int)grid_cells[l].size(); y++) {
+            for (int x = 0; x < (int)grid_cells[l][y].size(); x++) {
+                if (grid_cells[l][y][x].ws_id == workspace_id)
+                    return l;
+            }
         }
     }
-
-    size_t next_free = 0;
-    for (WORKSPACEID ws_id : workspace_ids) {
-        if (pinned_positions.contains(ws_id))
-            continue;
-
-        while (next_free < slot_to_ws.size() && slot_to_ws[next_free] != WORKSPACE_INVALID)
-            ++next_free;
-
-        if (next_free >= slot_to_ws.size())
-            break;
-
-        slot_to_ws[next_free] = ws_id;
-    }
-
-    for (size_t slot = 0; slot < slot_to_ws.size(); ++slot) {
-        if (slot_to_ws[slot] == workspace_id)
-            return (int)slot / ws_per_layer;
-    }
-
     return layer;
 }
 
@@ -223,8 +224,8 @@ WORKSPACEID HTLayoutGrid::on_move_swipe_end() {
     build_overview_layout(HT_VIEW_CLOSED);
     WORKSPACEID closest = WORKSPACE_INVALID;
     double closest_dist = 1e9;
-    for (const auto& [ws_id, box] : overview_layout) {
-        const float dist_sq = offset->value().distanceSq(Vector2D {-box.box.x, -box.box.y});
+    for (const auto& [ws_id, ws_layout] : overview_layout) {
+        const float dist_sq = offset->value().distanceSq(Vector2D {-ws_layout.box.x, -ws_layout.box.y});
         if (dist_sq < closest_dist) {
             closest_dist = dist_sq;
             closest = ws_id;
@@ -239,7 +240,7 @@ void HTLayoutGrid::close_open_lerp(float perc) {
         return;
 
     double open_scale =
-        calculate_ws_box(0, 0, HT_VIEW_OPENED).w / monitor->m_transformedSize.x; // 1 / ROWS
+        calculate_ws_box(0, 0, HT_VIEW_OPENED).w / monitor->m_transformedSize.x;
     Vector2D open_pos = {0, 0};
 
     layer = get_workspace_layer(monitor->m_activeWorkspace->m_id);
@@ -272,8 +273,7 @@ void HTLayoutGrid::on_show(CallbackFun on_complete) {
     if (monitor == nullptr)
         return;
 
-    *scale = calculate_ws_box(0, 0, HT_VIEW_OPENED).w / monitor->m_transformedSize.x; // 1 / ROWS
-    // Offset for the whole grid of workspaces
+    *scale = calculate_ws_box(0, 0, HT_VIEW_OPENED).w / monitor->m_transformedSize.x;
     *offset = {0, 0};
 }
 
@@ -293,7 +293,7 @@ void HTLayoutGrid::on_hide(CallbackFun on_complete) {
     layer = get_workspace_layer(monitor->m_activeWorkspace->m_id);
     build_overview_layout(HT_VIEW_CLOSED);
     *scale = 1.;
-    // End workspace to end up on
+
     const auto active_it = overview_layout.find(monitor->m_activeWorkspace->m_id);
     if (active_it == overview_layout.end())
         return;
@@ -315,14 +315,13 @@ void HTLayoutGrid::on_move(WORKSPACEID old_id, WORKSPACEID new_id, CallbackFun o
     if (old_workspace == nullptr || new_workspace == nullptr)
         return;
 
-    // prevent the thing from animating
     old_workspace->m_renderOffset->warp();
     new_workspace->m_renderOffset->warp();
 
     layer = get_workspace_layer(new_id);
     build_overview_layout(HT_VIEW_CLOSED);
     *scale = 1.;
-    // Target workspace to animate to
+
     const auto target_it = overview_layout.find(new_id);
     if (target_it == overview_layout.end())
         return;
@@ -381,7 +380,6 @@ CBox HTLayoutGrid::calculate_ws_box(int x, int y, HTViewStage stage) {
     if (monitor == nullptr)
         return {};
 
-    // Monitor may not have its final size yet during connect/reconnect
     if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
         return {};
 
@@ -405,7 +403,6 @@ CBox HTLayoutGrid::calculate_ws_box(int x, int y, HTViewStage stage) {
     const double mon_aspect = monitor->m_transformedSize.x / monitor->m_transformedSize.y;
     Vector2D start_offset {};
 
-    // make correct aspect ratio
     if (render_y * mon_aspect > render_x) {
         start_offset.y = (render_y - render_x / mon_aspect) * ROWS / 2.f;
         render_y = render_x / mon_aspect;
@@ -443,104 +440,98 @@ void HTLayoutGrid::build_overview_layout(HTViewStage stage) {
             return true;
         return lhs->m_id < rhs->m_id;
     });
-    const int ws_per_layer = std::max(1, ROWS * COLS);
     const int effective_layers = get_effective_layer_count(workspaces.size());
     layer = std::clamp(layer, 0, effective_layers - 1);
 
     overview_layout.clear();
 
-    for (auto it = pinned_positions.begin(); it != pinned_positions.end(); ) {
-        const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(it->first);
-        if (workspace == nullptr || workspace->inert() || workspace->m_isSpecialWorkspace)
-            it = pinned_positions.erase(it);
-        else
-            ++it;
+    // Resize grid_cells to match effective layers (only new cells get default-initialized
+    // by resize; existing cells preserve their ws_id / is_pinned state)
+    grid_cells.resize(effective_layers);
+    for (int l = 0; l < effective_layers; l++) {
+        grid_cells[l].resize(ROWS);
+        for (int y = 0; y < ROWS; y++) {
+            grid_cells[l][y].resize(COLS);
+        }
     }
 
-    const int total_slots = effective_layers * ws_per_layer;
-    std::vector<WORKSPACEID> slot_to_ws(total_slots, WORKSPACE_INVALID);
-    std::vector<bool> slot_occupied(total_slots, false);
-    std::unordered_map<WORKSPACEID, int> ws_to_slot;
-
-    std::vector<std::pair<WORKSPACEID, int>> pinned_slots;
-    pinned_slots.reserve(pinned_positions.size());
-    for (const auto& [ws_id, slot] : pinned_positions)
-        pinned_slots.emplace_back(ws_id, slot);
-
-    std::ranges::sort(pinned_slots, [](const auto& lhs, const auto& rhs) {
-        if (lhs.second != rhs.second)
-            return lhs.second < rhs.second;
-        return lhs.first < rhs.first;
-    });
-
-    // Reserve every still-valid pinned slot first, even if the workspace is not
-    // currently on this monitor. This prevents monitor switches from causing
-    // unrelated workspaces to reflow into positions that should stay stable.
-    for (const auto& [ws_id, slot] : pinned_slots) {
-        if (slot >= 0 && slot < total_slots && !slot_occupied[slot])
-            slot_occupied[slot] = true;
-    }
-
-    for (PHLWORKSPACE workspace : workspaces) {
-        if (workspace == nullptr)
-            continue;
-
-        auto pin_it = pinned_positions.find(workspace->m_id);
-        if (pin_it != pinned_positions.end()) {
-            const int slot = pin_it->second;
-            if (slot >= 0 && slot < total_slots && slot_to_ws[slot] == WORKSPACE_INVALID) {
-                slot_to_ws[slot] = workspace->m_id;
-                ws_to_slot[workspace->m_id] = slot;
-            } else {
-                pinned_positions.erase(pin_it);
+    // Clean up stale workspace references; do NOT reset occupied/pinned state
+    // for cells whose workspace is still valid, otherwise pin_workspace_to_slot
+    // results survive the next frame.
+    for (int l = 0; l < effective_layers; l++) {
+        for (int y = 0; y < (int)grid_cells[l].size(); y++) {
+            for (int x = 0; x < (int)grid_cells[l][y].size(); x++) {
+                auto& cell = grid_cells[l][y][x];
+                if (cell.ws_id != WORKSPACE_INVALID) {
+                    const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(cell.ws_id);
+                    if (workspace == nullptr || workspace->inert() || workspace->m_isSpecialWorkspace) {
+                        cell.ws_id = WORKSPACE_INVALID;
+                        cell.occupied = false;
+                        cell.is_pinned = false;
+                    }
+                }
             }
         }
     }
 
-    int next_free = 0;
+    // Place every workspace that belongs to this monitor: if it already has a
+    // cell in the grid (from a previous frame or a pin), keep it there; otherwise
+    // fill the first truly empty cell.
     for (PHLWORKSPACE workspace : workspaces) {
         if (workspace == nullptr)
             continue;
-        if (ws_to_slot.contains(workspace->m_id))
+
+        bool already_placed = false;
+        for (int l = 0; l < effective_layers && !already_placed; l++) {
+            for (int y = 0; y < (int)grid_cells[l].size() && !already_placed; y++) {
+                for (int x = 0; x < (int)grid_cells[l][y].size() && !already_placed; x++) {
+                    if (grid_cells[l][y][x].ws_id == workspace->m_id)
+                        already_placed = true;
+                }
+            }
+        }
+        if (already_placed)
             continue;
 
-        while (next_free < total_slots && slot_occupied[next_free])
-            ++next_free;
-
-        if (next_free >= total_slots)
-            break;
-
-        slot_to_ws[next_free] = workspace->m_id;
-        slot_occupied[next_free] = true;
-        ws_to_slot[workspace->m_id] = next_free;
-        // Remember auto-placed workspaces so the next rebuild keeps the same
-        // order instead of depending on transient compositor workspace lists.
-        pinned_positions[workspace->m_id] = next_free;
-        ++next_free;
+        bool placed = false;
+        for (int l = 0; l < effective_layers && !placed; l++) {
+            for (int y = 0; y < ROWS && !placed; y++) {
+                for (int x = 0; x < COLS && !placed; x++) {
+                    auto& cell = grid_cells[l][y][x];
+                    if (cell.ws_id == WORKSPACE_INVALID) {
+                        cell.ws_id = workspace->m_id;
+                        cell.occupied = true;
+                        cell.is_pinned = false;
+                        placed = true;
+                    }
+                }
+            }
+        }
     }
 
-    for (const auto& [ws_id, slot] : ws_to_slot) {
-        const int layer_start = layer * ws_per_layer;
-        const int layer_end = layer_start + ws_per_layer;
-        if (slot < layer_start || slot >= layer_end)
-            continue;
+    // Populate overview_layout from grid_cells for the current layer
+    if (layer >= 0 && layer < effective_layers) {
+        for (int y = 0; y < ROWS; y++) {
+            for (int x = 0; x < COLS; x++) {
+                const auto& cell = grid_cells[layer][y][x];
+                if (cell.ws_id == WORKSPACE_INVALID)
+                    continue;
 
-        int local_i = slot - layer_start;
-        int x = local_i % COLS;
-        int y = local_i / COLS;
-        PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(ws_id);
-        if (workspace == nullptr)
-            continue;
+                PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(cell.ws_id);
+                if (workspace == nullptr)
+                    continue;
 
-        const CBox ws_box = calculate_ws_box(x, y, stage);
-        overview_layout[ws_id] = HTWorkspace {
-            x,
-            y,
-            ws_box,
-            ws_id,
-            workspace->m_name,
-            monitor->m_id,
-        };
+                const CBox ws_box = calculate_ws_box(x, y, stage);
+                overview_layout[cell.ws_id] = HTWorkspace {
+                    x,
+                    y,
+                    ws_box,
+                    cell.ws_id,
+                    workspace->m_name,
+                    monitor->m_id,
+                };
+            }
+        }
     }
 }
 
@@ -575,8 +566,6 @@ void HTLayoutGrid::render() {
     data.box = monitor_box;
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(data));
 
-    // Do a dance with active workspaces: Hyprland will only properly render the
-    // current active one so make the workspace active before rendering it, etc
     const PHLWORKSPACE start_workspace = monitor->m_activeWorkspace;
     if (start_workspace == nullptr)
         return;
@@ -593,39 +582,34 @@ void HTLayoutGrid::render() {
 
     const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+    const int effective_layers = grid_cells.size();
 
-    std::unordered_map<int, WORKSPACEID> grid_to_ws;
-    for (const auto& [ws_id, ws_layout] : overview_layout) {
-        grid_to_ws[ws_layout.y * COLS + ws_layout.x] = ws_id;
-    }
+    if (layer < 0 || layer >= effective_layers)
+        return;
 
     CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
     for (int y = 0; y < ROWS; y++) {
         for (int x = 0; x < COLS; x++) {
-            const int grid_key = y * COLS + x;
-            const bool has_ws = grid_to_ws.contains(grid_key);
+            const auto& cell = grid_cells[layer][y][x];
+            const bool has_ws = cell.ws_id != WORKSPACE_INVALID;
 
             CBox ws_box;
             WORKSPACEID ws_id = WORKSPACE_INVALID;
             if (has_ws) {
-                ws_id = grid_to_ws[grid_key];
+                ws_id = cell.ws_id;
                 const auto& ws_layout = overview_layout[ws_id];
                 ws_box = ws_layout.box;
             } else {
                 ws_box = calculate_ws_box(x, y, HT_VIEW_ANIMATING);
             }
 
-            // Skip if the box is empty
             if (ws_box.width < 0.01 || ws_box.height < 0.01)
                 continue;
 
-            // renderModif translation used by renderWorkspace is weird so need
-            // to scale the translation up as well. Geometry is also calculated from pixel size and not transformed size??
             CBox render_box = {{ws_box.pos() / scale->value()}, ws_box.size()};
             if (monitor->m_transform % 2 == 1)
                 std::swap(render_box.w, render_box.h);
 
-            // render active one last
             if (has_ws && ws_id == start_workspace->m_id && start_workspace != nullptr)
                 continue;
 
@@ -673,7 +657,6 @@ void HTLayoutGrid::render() {
                     workspace->m_visible = false;
                 }
             } else {
-                // If a workspace is not allocated, then just render the layers
                 ((render_workspace_t)(render_workspace_hook->m_original))(
                     g_pHyprRenderer.get(),
                     monitor,
@@ -694,14 +677,10 @@ void HTLayoutGrid::render() {
     );
     start_workspace->m_visible = true;
 
-    // Render active workspace last so the dragging window is always on top when let go of
     const auto active_it = overview_layout.find(start_workspace->m_id);
     if (start_workspace != nullptr && active_it != overview_layout.end()) {
         CBox ws_box = active_it->second.box;
-        // make sure box is not empty
         if (ws_box.width > 0.01 && ws_box.height > 0.01) {
-            // renderModif translation used by renderWorkspace is weird so need
-            // to scale the translation up as well. Geometry is also calculated from pixel size and not transformed size??
             CBox render_box = {{ws_box.pos() / scale->value()}, ws_box.size()};
             if (monitor->m_transform % 2 == 1)
                 std::swap(render_box.w, render_box.h);

--- a/src/layout/grid.hpp
+++ b/src/layout/grid.hpp
@@ -18,6 +18,7 @@ class HTLayoutGrid: public HTLayoutBase {
     virtual ~HTLayoutGrid() = default;
 
     std::unordered_map<WORKSPACEID, int> pinned_positions;
+    int last_layer_cell = 0;
 
     void pin_workspace_to_slot(WORKSPACEID ws_id, int slot);
     void unpin_workspace(WORKSPACEID ws_id);

--- a/src/layout/grid.hpp
+++ b/src/layout/grid.hpp
@@ -11,13 +11,22 @@ class HTLayoutGrid: public HTLayoutBase {
     PHLANIMVAR<Vector2D> offset;
 
     int get_effective_layer_count(size_t workspace_count);
+    int get_max_occupied_layer();
     int get_workspace_layer(WORKSPACEID workspace_id);
 
   public:
     HTLayoutGrid(VIEWID view_id);
     virtual ~HTLayoutGrid() = default;
 
-    std::unordered_map<WORKSPACEID, int> pinned_positions;
+    struct HTGridCell {
+        WORKSPACEID ws_id = WORKSPACE_INVALID;
+        bool occupied = false;
+        bool is_pinned = false;
+    };
+
+    // 3D grid: [layer][row][col]
+    std::vector<std::vector<std::vector<HTGridCell>>> grid_cells;
+
     int last_layer_cell = 0;
 
     void pin_workspace_to_slot(WORKSPACEID ws_id, int slot);

--- a/src/layout/grid.hpp
+++ b/src/layout/grid.hpp
@@ -10,6 +10,9 @@ class HTLayoutGrid: public HTLayoutBase {
     PHLANIMVAR<float> scale;
     PHLANIMVAR<Vector2D> offset;
 
+    int get_effective_layer_count(size_t workspace_count);
+    int get_workspace_layer(WORKSPACEID workspace_id);
+
   public:
     HTLayoutGrid(VIEWID view_id);
     virtual ~HTLayoutGrid() = default;

--- a/src/layout/grid.hpp
+++ b/src/layout/grid.hpp
@@ -17,6 +17,13 @@ class HTLayoutGrid: public HTLayoutBase {
     HTLayoutGrid(VIEWID view_id);
     virtual ~HTLayoutGrid() = default;
 
+    std::unordered_map<WORKSPACEID, int> pinned_positions;
+
+    void pin_workspace_to_slot(WORKSPACEID ws_id, int slot);
+    void unpin_workspace(WORKSPACEID ws_id);
+
+    std::pair<int, int> get_grid_cell_from_global(Vector2D pos);
+
     virtual std::string layout_name();
 
     virtual CBox calculate_ws_box(int x, int y, HTViewStage stage);

--- a/src/layout/grid.hpp
+++ b/src/layout/grid.hpp
@@ -22,7 +22,7 @@ class HTLayoutGrid: public HTLayoutBase {
     void pin_workspace_to_slot(WORKSPACEID ws_id, int slot);
     void unpin_workspace(WORKSPACEID ws_id);
 
-    std::pair<int, int> get_grid_cell_from_global(Vector2D pos);
+    std::tuple<int, int, int> get_grid_cell_from_global(Vector2D pos);
 
     virtual std::string layout_name();
 

--- a/src/layout/grid.hpp
+++ b/src/layout/grid.hpp
@@ -6,6 +6,13 @@
 #include "layout_base.hpp"
 
 class HTLayoutGrid: public HTLayoutBase {
+  public:
+    struct HTGridCell {
+        WORKSPACEID ws_id = WORKSPACE_INVALID;
+        bool occupied = false;
+        bool is_pinned = false;
+    };
+
   private:
     PHLANIMVAR<float> scale;
     PHLANIMVAR<Vector2D> offset;
@@ -13,18 +20,14 @@ class HTLayoutGrid: public HTLayoutBase {
     int get_effective_layer_count(size_t workspace_count);
     int get_max_occupied_layer();
     int get_workspace_layer(WORKSPACEID workspace_id);
+    HTGridCell* cell_at(int layer, int y, int x);
+    const HTGridCell* cell_at(int layer, int y, int x) const;
+    HTGridCell* find_cell(WORKSPACEID ws_id);
 
   public:
     HTLayoutGrid(VIEWID view_id);
     virtual ~HTLayoutGrid() = default;
 
-    struct HTGridCell {
-        WORKSPACEID ws_id = WORKSPACE_INVALID;
-        bool occupied = false;
-        bool is_pinned = false;
-    };
-
-    // 3D grid: [layer][row][col]
     std::vector<std::vector<std::vector<HTGridCell>>> grid_cells;
 
     int last_layer_cell = 0;

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -92,7 +92,6 @@ void HTLayoutBase::render_workspace(PHLWORKSPACE ws, CBox render_box, bool is_ac
         return;
 
     if (ws != nullptr) {
-        monitor->m_activeWorkspace = ws;
         g_pDesktopAnimationManager->startAnimation(
             ws,
             CDesktopAnimationManager::ANIMATION_TYPE_IN,

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -1,5 +1,7 @@
 #include <any>
+#include <limits>
 #include <sstream>
+#include <unordered_set>
 
 #define private public
 #include <hyprland/src/config/ConfigManager.hpp>
@@ -122,6 +124,30 @@ std::vector<PHLWORKSPACE> HTLayoutBase::get_monitor_workspaces() {
     return workspaces;
 }
 
+std::vector<WORKSPACEID> HTLayoutBase::get_available_workspace_ids(size_t count) {
+    std::vector<WORKSPACEID> ids;
+    std::unordered_set<WORKSPACEID> occupied;
+
+    for (PHLWORKSPACE workspace : g_pCompositor->getWorkspacesCopy()) {
+        if (workspace == nullptr || workspace->inert())
+            continue;
+        occupied.insert(workspace->m_id);
+    }
+
+    WORKSPACEID candidate = 1;
+    while (ids.size() < count) {
+        if (!occupied.contains(candidate) && !g_pCompositor->workspaceIDOutOfBounds(candidate)) {
+            ids.push_back(candidate);
+            occupied.insert(candidate);
+        }
+        if (candidate == std::numeric_limits<WORKSPACEID>::max())
+            break;
+        candidate++;
+    }
+
+    return ids;
+}
+
 PHLWORKSPACE HTLayoutBase::get_workspace_from_layout(WORKSPACEID workspace_id) {
     if (!overview_layout.contains(workspace_id))
         return nullptr;
@@ -129,6 +155,39 @@ PHLWORKSPACE HTLayoutBase::get_workspace_from_layout(WORKSPACEID workspace_id) {
     PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(workspace_id);
     if (!is_monitor_workspace(workspace))
         return nullptr;
+    return workspace;
+}
+
+PHLWORKSPACE HTLayoutBase::get_or_create_workspace_from_layout(WORKSPACEID workspace_id) {
+    PHLWORKSPACE workspace = get_workspace_from_layout(workspace_id);
+    if (workspace != nullptr)
+        return workspace;
+
+    const PHLMONITOR monitor = get_monitor();
+    if (monitor == nullptr)
+        return nullptr;
+
+    const auto it = overview_layout.find(workspace_id);
+    if (it == overview_layout.end() || !it->second.is_placeholder)
+        return nullptr;
+    if (it->second.monitor_id != monitor->m_id || workspace_id == WORKSPACE_INVALID)
+        return nullptr;
+    if (g_pCompositor->getWorkspaceByID(workspace_id) != nullptr)
+        return nullptr;
+    if (g_pCompositor->workspaceIDOutOfBounds(workspace_id))
+        return nullptr;
+
+    workspace = g_pCompositor->createNewWorkspace(workspace_id, monitor->m_id);
+    if (!is_monitor_workspace(workspace))
+        return nullptr;
+
+    Log::logger->log(
+        LOG,
+        "[Hyprtasking] created workspace {} ({}) on monitor {} for empty tile",
+        workspace->m_id,
+        workspace->m_name,
+        monitor->m_name
+    );
     return workspace;
 }
 

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -127,7 +127,7 @@ PHLWORKSPACE HTLayoutBase::get_workspace_from_layout(WORKSPACEID workspace_id) {
         return nullptr;
 
     PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(workspace_id);
-    if (workspace == nullptr || workspace->inert() || workspace->m_isSpecialWorkspace)
+    if (!is_monitor_workspace(workspace))
         return nullptr;
     return workspace;
 }

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -1,7 +1,5 @@
 #include <any>
-#include <limits>
 #include <sstream>
-#include <unordered_set>
 
 #define private public
 #include <hyprland/src/config/ConfigManager.hpp>
@@ -124,30 +122,6 @@ std::vector<PHLWORKSPACE> HTLayoutBase::get_monitor_workspaces() {
     return workspaces;
 }
 
-std::vector<WORKSPACEID> HTLayoutBase::get_available_workspace_ids(size_t count) {
-    std::vector<WORKSPACEID> ids;
-    std::unordered_set<WORKSPACEID> occupied;
-
-    for (PHLWORKSPACE workspace : g_pCompositor->getWorkspacesCopy()) {
-        if (workspace == nullptr || workspace->inert())
-            continue;
-        occupied.insert(workspace->m_id);
-    }
-
-    WORKSPACEID candidate = 1;
-    while (ids.size() < count) {
-        if (!occupied.contains(candidate) && !g_pCompositor->workspaceIDOutOfBounds(candidate)) {
-            ids.push_back(candidate);
-            occupied.insert(candidate);
-        }
-        if (candidate == std::numeric_limits<WORKSPACEID>::max())
-            break;
-        candidate++;
-    }
-
-    return ids;
-}
-
 PHLWORKSPACE HTLayoutBase::get_workspace_from_layout(WORKSPACEID workspace_id) {
     if (!overview_layout.contains(workspace_id))
         return nullptr;
@@ -155,39 +129,6 @@ PHLWORKSPACE HTLayoutBase::get_workspace_from_layout(WORKSPACEID workspace_id) {
     PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(workspace_id);
     if (!is_monitor_workspace(workspace))
         return nullptr;
-    return workspace;
-}
-
-PHLWORKSPACE HTLayoutBase::get_or_create_workspace_from_layout(WORKSPACEID workspace_id) {
-    PHLWORKSPACE workspace = get_workspace_from_layout(workspace_id);
-    if (workspace != nullptr)
-        return workspace;
-
-    const PHLMONITOR monitor = get_monitor();
-    if (monitor == nullptr)
-        return nullptr;
-
-    const auto it = overview_layout.find(workspace_id);
-    if (it == overview_layout.end() || !it->second.is_placeholder)
-        return nullptr;
-    if (it->second.monitor_id != monitor->m_id || workspace_id == WORKSPACE_INVALID)
-        return nullptr;
-    if (g_pCompositor->getWorkspaceByID(workspace_id) != nullptr)
-        return nullptr;
-    if (g_pCompositor->workspaceIDOutOfBounds(workspace_id))
-        return nullptr;
-
-    workspace = g_pCompositor->createNewWorkspace(workspace_id, monitor->m_id);
-    if (!is_monitor_workspace(workspace))
-        return nullptr;
-
-    Log::logger->log(
-        LOG,
-        "[Hyprtasking] created workspace {} ({}) on monitor {} for empty tile",
-        workspace->m_id,
-        workspace->m_name,
-        monitor->m_name
-    );
     return workspace;
 }
 

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -19,7 +19,7 @@
 #include "layout_base.hpp"
 
 HTLayoutBase::HTLayoutBase(VIEWID new_view_id)
-    : view_id(new_view_id), par_view(ht_manager != nullptr ? ht_manager->get_view_from_id(new_view_id) : nullptr) {
+    : view_id(new_view_id) {
 }
 
 void HTLayoutBase::on_move_swipe(Vector2D delta) {
@@ -175,6 +175,8 @@ void HTLayoutBase::post_render() {
 }
 
 PHLMONITOR HTLayoutBase::get_monitor() {
+    if (par_view == nullptr && ht_manager != nullptr)
+        par_view = ht_manager->get_view_from_id(view_id);
     if (par_view == nullptr)
         return nullptr;
     return par_view->get_monitor();

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -92,6 +92,7 @@ void HTLayoutBase::render_workspace(PHLWORKSPACE ws, CBox render_box, bool is_ac
         return;
 
     if (ws != nullptr) {
+        monitor->m_activeWorkspace = ws;
         g_pDesktopAnimationManager->startAnimation(
             ws,
             CDesktopAnimationManager::ANIMATION_TYPE_IN,

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -99,6 +99,39 @@ PHLMONITOR HTLayoutBase::get_monitor() {
     return par_view->get_monitor();
 }
 
+bool HTLayoutBase::is_monitor_workspace(PHLWORKSPACE workspace) {
+    const PHLMONITOR monitor = get_monitor();
+    if (monitor == nullptr || workspace == nullptr)
+        return false;
+    if (workspace->inert() || workspace->m_isSpecialWorkspace)
+        return false;
+    return workspace->monitorID() == monitor->m_id;
+}
+
+std::vector<PHLWORKSPACE> HTLayoutBase::get_monitor_workspaces() {
+    std::vector<PHLWORKSPACE> workspaces;
+    const PHLMONITOR monitor = get_monitor();
+    if (monitor == nullptr)
+        return workspaces;
+
+    for (PHLWORKSPACE workspace : g_pCompositor->getWorkspacesCopy()) {
+        if (!is_monitor_workspace(workspace))
+            continue;
+        workspaces.push_back(workspace);
+    }
+    return workspaces;
+}
+
+PHLWORKSPACE HTLayoutBase::get_workspace_from_layout(WORKSPACEID workspace_id) {
+    if (!overview_layout.contains(workspace_id))
+        return nullptr;
+
+    PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(workspace_id);
+    if (!is_monitor_workspace(workspace))
+        return nullptr;
+    return workspace;
+}
+
 WORKSPACEID HTLayoutBase::get_ws_id_from_global(Vector2D pos) {
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
@@ -131,8 +164,8 @@ CBox HTLayoutBase::get_global_window_box(PHLWINDOW window, WORKSPACEID workspace
     if (monitor == nullptr)
         return {};
 
-    const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(workspace_id);
-    if (workspace == nullptr || workspace->m_monitor != monitor)
+    const PHLWORKSPACE workspace = get_workspace_from_layout(workspace_id);
+    if (workspace == nullptr)
         return {};
 
     const CBox ws_window_box = window->getWindowMainSurfaceBox();
@@ -148,7 +181,11 @@ CBox HTLayoutBase::get_global_window_box(PHLWINDOW window, WORKSPACEID workspace
 }
 
 CBox HTLayoutBase::get_global_ws_box(WORKSPACEID workspace_id) {
-    const CBox scaled_ws_box = overview_layout[workspace_id].box;
+    const auto it = overview_layout.find(workspace_id);
+    if (it == overview_layout.end())
+        return {};
+
+    const CBox scaled_ws_box = it->second.box;
     const Vector2D top_left = local_ws_scaled_to_global(scaled_ws_box.pos(), workspace_id);
     const Vector2D bottom_right =
         local_ws_scaled_to_global(scaled_ws_box.pos() + scaled_ws_box.size(), workspace_id);
@@ -160,7 +197,11 @@ Vector2D HTLayoutBase::global_to_local_ws_unscaled(Vector2D pos, WORKSPACEID wor
     if (monitor == nullptr)
         return {};
 
-    CBox workspace_box = overview_layout[workspace_id].box;
+    const auto it = overview_layout.find(workspace_id);
+    if (it == overview_layout.end())
+        return {};
+
+    CBox workspace_box = it->second.box;
     if (workspace_box.empty())
         return {};
     pos -= monitor->m_position;
@@ -186,7 +227,11 @@ Vector2D HTLayoutBase::local_ws_unscaled_to_global(Vector2D pos, WORKSPACEID wor
     if (monitor == nullptr)
         return {};
 
-    CBox workspace_box = overview_layout[workspace_id].box;
+    const auto it = overview_layout.find(workspace_id);
+    if (it == overview_layout.end())
+        return {};
+
+    CBox workspace_box = it->second.box;
     if (workspace_box.empty())
         return {};
     pos *= workspace_box.w / monitor->m_transformedSize.x;

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -127,7 +127,7 @@ PHLWORKSPACE HTLayoutBase::get_workspace_from_layout(WORKSPACEID workspace_id) {
         return nullptr;
 
     PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(workspace_id);
-    if (!is_monitor_workspace(workspace))
+    if (workspace == nullptr || workspace->inert() || workspace->m_isSpecialWorkspace)
         return nullptr;
     return workspace;
 }

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -1,25 +1,28 @@
-#include <any>
-#include <sstream>
-
-#define private public
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/desktop/DesktopTypes.hpp>
+#include <hyprland/src/managers/animation/DesktopAnimationManager.hpp>
 #include <hyprland/src/managers/input/InputManager.hpp>
+#include <hyprland/src/layout/LayoutManager.hpp>
+// Hyprland exposes render pass internals privately; this targeted workaround is
+// still required for CRenderPass::m_passElements cleanup in supported versions.
+#define private public
 #include <hyprland/src/render/Renderer.hpp>
-#include <hyprland/src/render/pass/ClearPassElement.hpp>
 #undef private
+#include <hyprland/src/render/pass/BorderPassElement.hpp>
+#include <hyprland/src/render/pass/ClearPassElement.hpp>
 
+#include "../config.hpp"
 #include "../globals.hpp"
 #include "../pass/pass_element.hpp"
+#include "../render.hpp"
 #include "../types.hpp"
 #include "layout_base.hpp"
 
-HTLayoutBase::HTLayoutBase(VIEWID new_view_id) : view_id(new_view_id) {
-    ;
+HTLayoutBase::HTLayoutBase(VIEWID new_view_id)
+    : view_id(new_view_id), par_view(ht_manager != nullptr ? ht_manager->get_view_from_id(new_view_id) : nullptr) {
 }
 
 void HTLayoutBase::on_move_swipe(Vector2D delta) {
-    ;
 }
 
 WORKSPACEID HTLayoutBase::on_move_swipe_end() {
@@ -66,17 +69,97 @@ float HTLayoutBase::drag_window_scale() {
 }
 
 void HTLayoutBase::init_position() {
-    ;
 }
 
 void HTLayoutBase::build_overview_layout(HTViewStage stage) {
-    ;
 }
 
 void HTLayoutBase::render() {
+    update_render_cache();
+
     CClearPassElement::SClearData data;
     data.color = CHyprColor {0};
     g_pHyprRenderer->m_renderPass.add(makeUnique<CClearPassElement>(data));
+}
+
+void HTLayoutBase::update_render_cache() {
+    cached_border_size = HTConfig::value_float("border_size");
+}
+
+void HTLayoutBase::render_workspace(PHLWORKSPACE ws, CBox render_box, bool is_active) {
+    const PHLMONITOR monitor = get_monitor();
+    if (monitor == nullptr)
+        return;
+
+    if (ws != nullptr) {
+        monitor->m_activeWorkspace = ws;
+        g_pDesktopAnimationManager->startAnimation(
+            ws,
+            CDesktopAnimationManager::ANIMATION_TYPE_IN,
+            false,
+            true
+        );
+        ws->m_visible = true;
+    }
+
+    ((render_workspace_t)(render_workspace_hook->m_original))(
+        g_pHyprRenderer.get(),
+        monitor,
+        ws,
+        Time::steadyNow(),
+        render_box
+    );
+
+    if (ws == nullptr || is_active)
+        return;
+
+    g_pDesktopAnimationManager->startAnimation(
+        ws,
+        CDesktopAnimationManager::ANIMATION_TYPE_OUT,
+        false,
+        true
+    );
+    ws->m_visible = false;
+}
+
+void HTLayoutBase::render_dragged_window() {
+    const PHLMONITOR monitor = get_monitor();
+    if (monitor == nullptr)
+        return;
+
+    const PHTVIEW cursor_view = ht_manager->get_view_from_cursor();
+    if (cursor_view == nullptr)
+        return;
+
+    const SP<Layout::ITarget> target = g_layoutManager->dragController()->target();
+    if (target == nullptr)
+        return;
+
+    const PHLWINDOW dragged_window = target->window();
+    if (dragged_window == nullptr)
+        return;
+
+    const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
+    const CBox window_box = dragged_window->getWindowMainSurfaceBox()
+                                .translate(-mouse_coords)
+                                .scale(cursor_view->layout->drag_window_scale())
+                                .translate(mouse_coords);
+    if (!window_box.intersection(monitor->logicalBox()).empty())
+        render_window_at_box(dragged_window, monitor, Time::steadyNow(), window_box);
+}
+
+void HTLayoutBase::render_border(CBox box, bool is_active) {
+    static auto PACTIVECOL = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.active_border");
+    static auto PINACTIVECOL = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.inactive_border");
+
+    auto* const active_col = (CGradientValueData*)(PACTIVECOL.ptr())->getData();
+    auto* const inactive_col = (CGradientValueData*)(PINACTIVECOL.ptr())->getData();
+
+    CBorderPassElement::SBorderData data;
+    data.box = box;
+    data.grad1 = is_active ? *active_col : *inactive_col;
+    data.borderSize = cached_border_size;
+    g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
 }
 
 const std::string CLEAR_PASS_ELEMENT_NAME = "CClearPassElement";
@@ -89,11 +172,9 @@ void HTLayoutBase::post_render() {
         return res;
     });
     g_pHyprRenderer->m_renderPass.add(makeUnique<HTPassElement>());
-    // g_pHyprOpenGL->setDamage(CRegion {CBox {0, 0, INT32_MAX, INT32_MAX}});
 }
 
 PHLMONITOR HTLayoutBase::get_monitor() {
-    const auto par_view = ht_manager->get_view_from_id(view_id);
     if (par_view == nullptr)
         return nullptr;
     return par_view->get_monitor();

--- a/src/layout/layout_base.hpp
+++ b/src/layout/layout_base.hpp
@@ -37,7 +37,6 @@ class HTLayoutBase {
         WORKSPACEID id = WORKSPACE_INVALID;
         std::string name;
         MONITORID monitor_id = -1;
-        bool is_placeholder = false;
     };
 
     virtual CBox calculate_ws_box(int x, int y, HTViewStage stage) = 0;
@@ -79,9 +78,7 @@ class HTLayoutBase {
     PHLMONITOR get_monitor();
     bool is_monitor_workspace(PHLWORKSPACE workspace);
     std::vector<PHLWORKSPACE> get_monitor_workspaces();
-    std::vector<WORKSPACEID> get_available_workspace_ids(size_t count);
     PHLWORKSPACE get_workspace_from_layout(WORKSPACEID workspace_id);
-    PHLWORKSPACE get_or_create_workspace_from_layout(WORKSPACEID workspace_id);
     WORKSPACEID get_ws_id_from_global(Vector2D pos);
     WORKSPACEID get_ws_id_from_xy(int x, int y);
     std::pair<int, int> get_current_ws_xy();

--- a/src/layout/layout_base.hpp
+++ b/src/layout/layout_base.hpp
@@ -37,6 +37,7 @@ class HTLayoutBase {
         WORKSPACEID id = WORKSPACE_INVALID;
         std::string name;
         MONITORID monitor_id = -1;
+        bool is_placeholder = false;
     };
 
     virtual CBox calculate_ws_box(int x, int y, HTViewStage stage) = 0;
@@ -78,7 +79,9 @@ class HTLayoutBase {
     PHLMONITOR get_monitor();
     bool is_monitor_workspace(PHLWORKSPACE workspace);
     std::vector<PHLWORKSPACE> get_monitor_workspaces();
+    std::vector<WORKSPACEID> get_available_workspace_ids(size_t count);
     PHLWORKSPACE get_workspace_from_layout(WORKSPACEID workspace_id);
+    PHLWORKSPACE get_or_create_workspace_from_layout(WORKSPACEID workspace_id);
     WORKSPACEID get_ws_id_from_global(Vector2D pos);
     WORKSPACEID get_ws_id_from_xy(int x, int y);
     std::pair<int, int> get_current_ws_xy();

--- a/src/layout/layout_base.hpp
+++ b/src/layout/layout_base.hpp
@@ -10,6 +10,9 @@
 
 #include "../types.hpp"
 
+class HTView;
+typedef SP<HTView> PHTVIEW;
+
 enum HTViewStage {
     HT_VIEW_ANIMATING,
     HT_VIEW_OPENED,
@@ -18,8 +21,15 @@ enum HTViewStage {
 
 class HTLayoutBase {
   protected:
-    // Same as monitor_id of the parent view
     VIEWID view_id;
+    PHTVIEW par_view;
+
+    float cached_border_size = 0.f;
+
+    void update_render_cache();
+    void render_workspace(PHLWORKSPACE ws, CBox render_box, bool is_active);
+    void render_dragged_window();
+    void render_border(CBox box, bool is_active);
 
   public:
     using CallbackFun = Hyprutils::Animation::CBaseAnimatedVariable::CallbackFun;
@@ -42,37 +52,25 @@ class HTLayoutBase {
     virtual CBox calculate_ws_box(int x, int y, HTViewStage stage) = 0;
     std::unordered_map<WORKSPACEID, HTWorkspace> overview_layout;
 
-    // Warp the show/hide animations to perc (from closed to open)
     virtual void close_open_lerp(float perc) = 0;
     virtual void on_show(CallbackFun on_complete = nullptr) = 0;
     virtual void on_hide(CallbackFun on_complete = nullptr) = 0;
     virtual void
     on_move(WORKSPACEID old_id, WORKSPACEID new_id, CallbackFun on_complete = nullptr) = 0;
     virtual void on_move_swipe(Vector2D delta);
-    // Returns the workspace id that the swipe should snap to
     virtual WORKSPACEID on_move_swipe_end();
 
-    // Get the workspace up/down left/right relative to the workspace at (x, y)
     virtual WORKSPACEID get_ws_id_in_direction(int x, int y, std::string& direction);
 
-    // Return true if should cancel
     virtual bool on_mouse_axis(double delta);
 
-    // Should return true if when active, hyprtasking should manage the mouse button actions
-    // (warping to appropriate position and smoothing the drag window, if it exists)
     virtual bool should_manage_mouse();
-    // Called assuming that at least one overview is active (not nec on this monitor)
     virtual bool should_render_window(PHLWINDOW window);
-    // The scale the drag window should be rendered at (about the mouse cursor)
     virtual float drag_window_scale();
-    // Only to be called when closed, init/reset the position in case of config/monitor change
     virtual void init_position();
-    // Populate overview_layout as if the overview was at a given stage
     virtual void build_overview_layout(HTViewStage stage);
-    // Render the overview
     virtual void render();
 
-    // Prevent simplification from happening in the plugin, remove all clear pass objects
     void post_render();
 
     PHLMONITOR get_monitor();

--- a/src/layout/layout_base.hpp
+++ b/src/layout/layout_base.hpp
@@ -4,7 +4,9 @@
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <hyprland/src/helpers/AnimatedVariable.hpp>
 #include <hyprutils/math/Box.hpp>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "../types.hpp"
 
@@ -32,6 +34,9 @@ class HTLayoutBase {
         int x;
         int y;
         CBox box;
+        WORKSPACEID id = WORKSPACE_INVALID;
+        std::string name;
+        MONITORID monitor_id = -1;
     };
 
     virtual CBox calculate_ws_box(int x, int y, HTViewStage stage) = 0;
@@ -71,6 +76,9 @@ class HTLayoutBase {
     void post_render();
 
     PHLMONITOR get_monitor();
+    bool is_monitor_workspace(PHLWORKSPACE workspace);
+    std::vector<PHLWORKSPACE> get_monitor_workspaces();
+    PHLWORKSPACE get_workspace_from_layout(WORKSPACEID workspace_id);
     WORKSPACEID get_ws_id_from_global(Vector2D pos);
     WORKSPACEID get_ws_id_from_xy(int x, int y);
     std::pair<int, int> get_current_ws_xy();

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -111,15 +111,15 @@ void HTLayoutLinear::on_move(WORKSPACEID old_id, WORKSPACEID new_id, CallbackFun
 
     const float GAP_SIZE = HTConfig::value<Hyprlang::FLOAT>("gap_size") * monitor->m_scale;
 
-    const PHLWORKSPACE new_ws = g_pCompositor->getWorkspaceByID(new_id);
-    if (new_ws == nullptr)
-        return;
-
     build_overview_layout(HT_VIEW_ANIMATING);
 
-    const float cur_screen_min_x = overview_layout[new_id].box.x - GAP_SIZE;
+    const auto target_it = overview_layout.find(new_id);
+    if (target_it == overview_layout.end() || get_workspace_from_layout(new_id) == nullptr)
+        return;
+
+    const float cur_screen_min_x = target_it->second.box.x - GAP_SIZE;
     const float cur_screen_max_x =
-        overview_layout[new_id].box.x + overview_layout[new_id].box.w + GAP_SIZE;
+        target_it->second.box.x + target_it->second.box.w + GAP_SIZE;
 
     if (cur_screen_min_x < 0) {
         *scroll_offset = scroll_offset->value() - cur_screen_min_x;
@@ -276,26 +276,19 @@ void HTLayoutLinear::build_overview_layout(HTViewStage stage) {
 
     overview_layout.clear();
 
-    std::vector<WORKSPACEID> monitor_workspaces;
-    for (PHLWORKSPACE workspace : g_pCompositor->getWorkspacesCopy()) {
+    const std::vector<PHLWORKSPACE> monitor_workspaces = get_monitor_workspaces();
+    for (const auto& [x, workspace] : monitor_workspaces | std::views::enumerate) {
         if (workspace == nullptr)
             continue;
-        if (workspace->m_monitor != monitor)
-            continue;
-        if (workspace->m_isSpecialWorkspace)
-            continue;
-        monitor_workspaces.push_back(workspace->m_id);
-    }
-    std::sort(monitor_workspaces.begin(), monitor_workspaces.end());
-
-    WORKSPACEID big_id = monitor_workspaces.back();
-    while (g_pCompositor->getWorkspaceByID(big_id) != nullptr)
-        big_id++;
-    monitor_workspaces.push_back(big_id);
-
-    for (const auto& [x, ws_id] : monitor_workspaces | std::views::enumerate) {
         CBox ws_box = calculate_ws_box(x, 0, stage);
-        overview_layout[ws_id] = {x, 0, ws_box};
+        overview_layout[workspace->m_id] = {
+            (int)x,
+            0,
+            ws_box,
+            workspace->m_id,
+            workspace->m_name,
+            monitor->m_id,
+        };
     }
 }
 
@@ -328,6 +321,8 @@ void HTLayoutLinear::render() {
     // Do a dance with active workspaces: Hyprland will only properly render the
     // current active one so make the workspace active before rendering it, etc
     const PHLWORKSPACE start_workspace = monitor->m_activeWorkspace;
+    if (start_workspace == nullptr)
+        return;
     g_pDesktopAnimationManager->startAnimation(
         start_workspace,
         CDesktopAnimationManager::ANIMATION_TYPE_OUT,
@@ -391,7 +386,7 @@ void HTLayoutLinear::render() {
     CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
     for (const auto& [ws_id, ws_layout] : overview_layout) {
         // Could be nullptr, in which we render only layers
-        const PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(ws_id);
+        const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
 
         // renderModif translation used by renderWorkspace is weird so need
         // to scale the translation up as well. Geometry is also calculated from pixel size and not transformed size??

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -361,7 +361,6 @@ void HTLayoutLinear::render() {
         true
     );
     big_ws->m_visible = false;
-    rendering_standard_ws = false;
 
     CBox view_box = {
         {0.f, calculate_y(monitor->m_transformedSize.y, view_offset->value(), HEIGHT)},

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -323,6 +323,21 @@ void HTLayoutLinear::render() {
     const PHLWORKSPACE start_workspace = monitor->m_activeWorkspace;
     if (start_workspace == nullptr)
         return;
+
+    CScopeGuard restore_workspace([this, &monitor, &start_workspace] {
+        rendering_standard_ws = false;
+        if (monitor == nullptr || start_workspace == nullptr)
+            return;
+        monitor->m_activeWorkspace = start_workspace;
+        g_pDesktopAnimationManager->startAnimation(
+            start_workspace,
+            CDesktopAnimationManager::ANIMATION_TYPE_IN,
+            false,
+            true
+        );
+        start_workspace->m_visible = true;
+    });
+
     g_pDesktopAnimationManager->startAnimation(
         start_workspace,
         CDesktopAnimationManager::ANIMATION_TYPE_OUT,

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -16,7 +16,6 @@
 
 #include "../config.hpp"
 #include "../globals.hpp"
-#include "../render.hpp"
 #include "layout_base.hpp"
 
 using Hyprutils::Utils::CScopeGuard;
@@ -58,7 +57,7 @@ void HTLayoutLinear::close_open_lerp(float perc) {
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
         return;
-    const float HEIGHT = HTConfig::value<Hyprlang::FLOAT>("linear:height") * monitor->m_scale;
+    const float HEIGHT = HTConfig::value_float("linear:height") * monitor->m_scale;
 
     view_offset->resetAllCallbacks();
     blur_strength->resetAllCallbacks();
@@ -78,7 +77,7 @@ void HTLayoutLinear::on_show(CallbackFun on_complete) {
     if (monitor == nullptr)
         return;
 
-    const float HEIGHT = HTConfig::value<Hyprlang::FLOAT>("linear:height") * monitor->m_scale;
+    const float HEIGHT = HTConfig::value_float("linear:height") * monitor->m_scale;
     *view_offset = HEIGHT;
     *blur_strength = 2.0;
     *dim_opacity = 0.4;
@@ -109,7 +108,7 @@ void HTLayoutLinear::on_move(WORKSPACEID old_id, WORKSPACEID new_id, CallbackFun
     if (monitor == nullptr)
         return;
 
-    const float GAP_SIZE = HTConfig::value<Hyprlang::FLOAT>("gap_size") * monitor->m_scale;
+    const float GAP_SIZE = HTConfig::value_float("gap_size") * monitor->m_scale;
 
     build_overview_layout(HT_VIEW_ANIMATING);
 
@@ -136,30 +135,27 @@ bool HTLayoutLinear::on_mouse_axis(double delta) {
     if (monitor == nullptr)
         return false;
 
-    const float GAP_SIZE = HTConfig::value<Hyprlang::FLOAT>("gap_size") * monitor->m_scale;
+    const float GAP_SIZE = HTConfig::value_float("gap_size") * monitor->m_scale;
 
     const float total_ws_width =
         (overview_layout.size() * (GAP_SIZE + calculate_ws_box(0, 0, HT_VIEW_ANIMATING).w))
         + GAP_SIZE;
 
-    // Stay at 0 if not long enough
     if (total_ws_width < monitor->m_transformedSize.x) {
         *scroll_offset = 0.;
         return true;
     }
 
     double new_offset = scroll_offset->goal()
-        + delta * HTConfig::value<Hyprlang::FLOAT>("linear:scroll_speed") * -10.f;
+        + delta * HTConfig::value_float("linear:scroll_speed") * -10.f;
 
     const float max_x = new_offset
         + (overview_layout.size() * (GAP_SIZE + calculate_ws_box(0, 0, HT_VIEW_ANIMATING).w))
         + GAP_SIZE;
 
-    // Snap to left
     if (new_offset > 0.)
         new_offset = 0.;
 
-    // Snap to right
     if (max_x < monitor->m_transformedSize.x)
         new_offset = new_offset + (monitor->m_transformedSize.x - max_x);
 
@@ -168,7 +164,7 @@ bool HTLayoutLinear::on_mouse_axis(double delta) {
 }
 
 const float calculate_y(float size_y, float offset_value, float max_offset) {
-    const bool top = HTConfig::value<Hyprlang::FLOAT>("linear:top");
+    const bool top = HTConfig::value("linear:top");
     if (top)
         return offset_value - max_offset;
     return size_y - offset_value;
@@ -179,7 +175,7 @@ bool HTLayoutLinear::should_manage_mouse() {
     if (monitor == nullptr)
         return 1;
 
-    const float HEIGHT = HTConfig::value<Hyprlang::FLOAT>("linear:height") * monitor->m_scale;
+    const float HEIGHT = HTConfig::value_float("linear:height") * monitor->m_scale;
 
     const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
     CBox scaled_view_box = {
@@ -242,12 +238,11 @@ CBox HTLayoutLinear::calculate_ws_box(int x, int y, HTViewStage stage) {
     if (monitor == nullptr)
         return {};
 
-    // Monitor may not have its final size yet during connect/reconnect
     if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
         return {};
 
-    const float HEIGHT = HTConfig::value<Hyprlang::FLOAT>("linear:height") * monitor->m_scale;
-    const float GAP_SIZE = HTConfig::value<Hyprlang::FLOAT>("gap_size") * monitor->m_scale;
+    const float HEIGHT = HTConfig::value_float("linear:height") * monitor->m_scale;
+    const float GAP_SIZE = HTConfig::value_float("gap_size") * monitor->m_scale;
 
     if (HEIGHT < 0 || HEIGHT > monitor->m_transformedSize.y)
         return {};
@@ -303,23 +298,14 @@ void HTLayoutLinear::render() {
     if (monitor == nullptr)
         return;
 
-    static auto PACTIVECOL = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.active_border");
-    static auto PINACTIVECOL = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.inactive_border");
-
-    auto* const ACTIVECOL = (CGradientValueData*)(PACTIVECOL.ptr())->getData();
-    auto* const INACTIVECOL = (CGradientValueData*)(PINACTIVECOL.ptr())->getData();
-
-    const float BORDERSIZE = HTConfig::value<Hyprlang::FLOAT>("border_size");
-    const float HEIGHT = HTConfig::value<Hyprlang::FLOAT>("linear:height") * monitor->m_scale;
-
-    const auto time = Time::steadyNow();
+    const int bg_color = HTConfig::value("bg_color");
+    const int blur_enabled = HTConfig::value("linear:blur");
+    const float HEIGHT = HTConfig::value_float("linear:height") * monitor->m_scale;
 
 
     g_pHyprRenderer->damageMonitor(monitor);
     g_pHyprOpenGL->m_renderData.pCurrentMonData->blurFBShouldRender = true;
 
-    // Do a dance with active workspaces: Hyprland will only properly render the
-    // current active one so make the workspace active before rendering it, etc
     const PHLWORKSPACE start_workspace = monitor->m_activeWorkspace;
     if (start_workspace == nullptr)
         return;
@@ -358,22 +344,13 @@ void HTLayoutLinear::render() {
     );
     big_ws->m_visible = true;
 
-    // use pixel size for geometry
     CBox mon_box = {{0, 0}, monitor->m_pixelSize};
-    // Render the current workspace on the screen
-    ((render_workspace_t)(render_workspace_hook->m_original))(
-        g_pHyprRenderer.get(),
-        monitor,
-        big_ws,
-        time,
-        mon_box
-    );
+    render_workspace(big_ws, mon_box, true);
 
-    // add blur/dim over the original workspace
     CRectPassElement::SRectData blur_data;
     blur_data.color = CHyprColor(0, 0, 0, dim_opacity->value());
     blur_data.box = mon_box;
-    blur_data.blur = (bool)HTConfig::value<Hyprlang::INT>("linear:blur");
+    blur_data.blur = (bool)blur_enabled;
     blur_data.blurA = blur_strength->value();
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(blur_data));
 
@@ -392,7 +369,7 @@ void HTLayoutLinear::render() {
     };
 
     CRectPassElement::SRectData data;
-    data.color = CHyprColor {HTConfig::value<Hyprlang::INT>("bg_color")}.stripA();
+    data.color = CHyprColor {bg_color}.stripA();
     data.box = view_box;
     g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(data));
 
@@ -400,11 +377,8 @@ void HTLayoutLinear::render() {
 
     CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
     for (const auto& [ws_id, ws_layout] : overview_layout) {
-        // Could be nullptr, in which we render only layers
         const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
 
-        // renderModif translation used by renderWorkspace is weird so need
-        // to scale the translation up as well. Geometry is also calculated from pixel size and not transformed size??
         CBox render_box = {
             {ws_layout.box.pos() / (ws_layout.box.w / monitor->m_transformedSize.x)},
             ws_layout.box.size()
@@ -416,50 +390,9 @@ void HTLayoutLinear::render() {
         if (global_box.intersection(global_mon_box).empty())
             continue;
 
-        const CGradientValueData border_col = workspace == big_ws ? *ACTIVECOL : *INACTIVECOL;
-        CBox border_box = ws_layout.box;
+        render_border(ws_layout.box, workspace == big_ws);
 
-        CBorderPassElement::SBorderData data;
-        data.box = border_box;
-        data.grad1 = border_col;
-        data.borderSize = BORDERSIZE;
-        g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(data));
-
-        if (workspace != nullptr) {
-            monitor->m_activeWorkspace = workspace;
-            g_pDesktopAnimationManager->startAnimation(
-                workspace,
-                CDesktopAnimationManager::ANIMATION_TYPE_IN,
-                false,
-                true
-            );
-            workspace->m_visible = true;
-
-            ((render_workspace_t)(render_workspace_hook->m_original))(
-                g_pHyprRenderer.get(),
-                monitor,
-                workspace,
-                time,
-                render_box
-            );
-
-            g_pDesktopAnimationManager->startAnimation(
-                workspace,
-                CDesktopAnimationManager::ANIMATION_TYPE_OUT,
-                false,
-                true
-            );
-            workspace->m_visible = false;
-        } else {
-            // If pWorkspace is null, then just render the layers
-            ((render_workspace_t)(render_workspace_hook->m_original))(
-                g_pHyprRenderer.get(),
-                monitor,
-                workspace,
-                time,
-                render_box
-            );
-        }
+        render_workspace(workspace, render_box, false);
     }
 
     monitor->m_activeWorkspace = start_workspace;
@@ -471,23 +404,5 @@ void HTLayoutLinear::render() {
     );
     start_workspace->m_visible = true;
 
-    // Render dragged window at mouse cursor
-    const PHTVIEW cursor_view = ht_manager->get_view_from_cursor();
-    if (cursor_view == nullptr)
-        return;
-
-    const SP<Layout::ITarget> target = g_layoutManager->dragController()->target();
-    if (target == nullptr)
-        return;
-
-    const PHLWINDOW dragged_window = target->window();
-    if (dragged_window == nullptr)
-        return;
-    const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
-    const CBox window_box = dragged_window->getWindowMainSurfaceBox()
-                                .translate(-mouse_coords)
-                                .scale(cursor_view->layout->drag_window_scale())
-                                .translate(mouse_coords);
-    if (!window_box.intersection(monitor->logicalBox()).empty())
-        render_window_at_box(dragged_window, monitor, time, window_box);
+    render_dragged_window();
 }

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -371,15 +371,5 @@ void HTLayoutLinear::render() {
         render_workspace(hovered_workspace, hovered_render_box, true);
     }
 
-    // Restore the pre-overview workspace as the real monitor active workspace.
-    monitor->m_activeWorkspace = start_workspace;
-    g_pDesktopAnimationManager->startAnimation(
-        start_workspace,
-        CDesktopAnimationManager::ANIMATION_TYPE_IN,
-        false,
-        true
-    );
-    start_workspace->m_visible = true;
-
     render_dragged_window();
 }

--- a/src/layout/linear.cpp
+++ b/src/layout/linear.cpp
@@ -302,7 +302,6 @@ void HTLayoutLinear::render() {
     const int blur_enabled = HTConfig::value("linear:blur");
     const float HEIGHT = HTConfig::value_float("linear:height") * monitor->m_scale;
 
-
     g_pHyprRenderer->damageMonitor(monitor);
     g_pHyprOpenGL->m_renderData.pCurrentMonData->blurFBShouldRender = true;
 
@@ -332,49 +331,16 @@ void HTLayoutLinear::render() {
     );
     start_workspace->m_visible = false;
 
-    const PHLWORKSPACE big_ws = monitor->m_activeWorkspace;
-
-    rendering_standard_ws = true;
-    monitor->m_activeWorkspace = big_ws;
-    g_pDesktopAnimationManager->startAnimation(
-        start_workspace,
-        CDesktopAnimationManager::ANIMATION_TYPE_IN,
-        false,
-        true
-    );
-    big_ws->m_visible = true;
-
-    CBox mon_box = {{0, 0}, monitor->m_pixelSize};
-    render_workspace(big_ws, mon_box, true);
-
-    CRectPassElement::SRectData blur_data;
-    blur_data.color = CHyprColor(0, 0, 0, dim_opacity->value());
-    blur_data.box = mon_box;
-    blur_data.blur = (bool)blur_enabled;
-    blur_data.blurA = blur_strength->value();
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(blur_data));
-
-    g_pDesktopAnimationManager->startAnimation(
-        start_workspace,
-        CDesktopAnimationManager::ANIMATION_TYPE_OUT,
-        false,
-        true
-    );
-    big_ws->m_visible = false;
-
-    CBox view_box = {
-        {0.f, calculate_y(monitor->m_transformedSize.y, view_offset->value(), HEIGHT)},
-        {(float)monitor->m_transformedSize.x, (float)HEIGHT}
-    };
-
-    CRectPassElement::SRectData data;
-    data.color = CHyprColor {bg_color}.stripA();
-    data.box = view_box;
-    g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(data));
-
     build_overview_layout(HT_VIEW_ANIMATING);
 
+    const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
+    const WORKSPACEID hovered_ws_id = get_ws_id_from_global(mouse_coords);
+
     CBox global_mon_box = {monitor->m_position, monitor->m_transformedSize};
+    PHLWORKSPACE hovered_workspace = nullptr;
+    CBox hovered_box;
+    CBox hovered_render_box;
+
     for (const auto& [ws_id, ws_layout] : overview_layout) {
         const PHLWORKSPACE workspace = get_workspace_from_layout(ws_id);
 
@@ -389,11 +355,23 @@ void HTLayoutLinear::render() {
         if (global_box.intersection(global_mon_box).empty())
             continue;
 
-        render_border(ws_layout.box, workspace == big_ws);
+        if (ws_id == hovered_ws_id) {
+            hovered_workspace = workspace;
+            hovered_box = ws_layout.box;
+            hovered_render_box = render_box;
+            continue;
+        }
 
+        render_border(ws_layout.box, false);
         render_workspace(workspace, render_box, false);
     }
 
+    if (hovered_workspace != nullptr) {
+        render_border(hovered_box, true);
+        render_workspace(hovered_workspace, hovered_render_box, true);
+    }
+
+    // Restore the pre-overview workspace as the real monitor active workspace.
     monitor->m_activeWorkspace = start_workspace;
     g_pDesktopAnimationManager->startAnimation(
         start_workspace,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,15 +217,17 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     }
 
     const int target_cell = source_index % ws_per_layer;
+    const int target_page_start = resulting_layer * ws_per_layer;
+    if (target_page_start >= (int)monitor_workspaces.size())
+        return {};
+
+    const int target_index = std::min(
+        target_page_start + target_cell,
+        (int)monitor_workspaces.size() - 1
+    );
+    const WORKSPACEID target_ws_id = monitor_workspaces[target_index]->m_id;
 
     set_layer(cursor_view, resulting_layer);
-    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-
-    const int target_x = target_cell % COLS;
-    const int target_y = target_cell / COLS;
-    const WORKSPACEID target_ws_id = cursor_view->layout->get_ws_id_from_xy(target_x, target_y);
-    if (target_ws_id == WORKSPACE_INVALID)
-        return {};
 
     cursor_view->move_id(target_ws_id, move_window);
     return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,11 +253,6 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     PHLWORKSPACE target_workspace = nullptr;
 
     if (target_ws_id == WORKSPACE_INVALID) {
-        // Avoid growing workspace IDs when just hopping between empty cells.
-        // If the current workspace is empty, move that workspace to the target.
-        if (!move_window)
-            remember_empty_workspace(active_workspace, monitor);
-
         target_workspace = create_workspace_for_monitor(monitor);
         if (target_workspace == nullptr) {
             set_layer(cursor_view, original_layer);
@@ -267,8 +262,8 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
 
         grid_layout->pin_workspace_to_slot(target_workspace->m_id, target_slot);
         target_ws_id = target_workspace->m_id;
-        // Reused or newly created empty workspaces may not be in
-        // overview_layout yet, so keep the pointer instead of looking it up.
+        // Newly created workspaces may not be in overview_layout yet, so keep
+        // the pointer instead of looking it up immediately.
     } else {
         grid_layout->pin_workspace_to_slot(target_ws_id, target_slot);
         target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
@@ -286,10 +281,8 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
 
     if (move_window) {
         const PHLWINDOW hovered_window = ht_manager->get_window_from_cursor();
-        if (hovered_window != nullptr) {
+        if (hovered_window != nullptr)
             g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, target_workspace);
-            remember_empty_workspace(active_workspace, monitor);
-        }
     }
 
     monitor->changeWorkspace(target_workspace);
@@ -342,7 +335,9 @@ static void hook_render_workspace(
         return;
     }
     const PHTVIEW view = ht_manager->get_view_from_monitor(monitor);
-    if ((view != nullptr && view->navigating) || ht_manager->has_active_view()) {
+    // Some render hooks can fire for monitors that do not have a registered
+    // hyprtasking view yet, especially around monitor hotplug/reload.
+    if (view != nullptr && ((view->navigating) || ht_manager->has_active_view())) {
         view->layout->render();
     } else {
         ((render_workspace_t)(render_workspace_hook
@@ -365,7 +360,9 @@ static uint32_t hook_is_solitary_blocked(void* thisptr, bool full) {
     PHTVIEW view = ht_manager->get_view_from_cursor();
     if (view == nullptr) {
         Log::logger->log(Log::ERR, "[Hyprtasking] View is nullptr in hook_is_solitary_blocked");
-        (*(origIsSolitaryBlocked)is_solitary_blocked_hook->m_original)(thisptr, full);
+        // Fall back to Hyprland when there is no cursor view instead of
+        // dereferencing nullptr below.
+        return (*(origIsSolitaryBlocked)is_solitary_blocked_hook->m_original)(thisptr, full);
     }
 
     if (view->active || view->navigating) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,6 +105,8 @@ static SDispatchResult dispatch_move(std::string arg) {
     } if (arg == "out") {
         return change_layer("+1", false);
     }
+    if (arg != "up" && arg != "down" && arg != "left" && arg != "right")
+        return {.success = false, .error = "invalid arg"};
     cursor_view->move(arg, false);
     return {};
 }
@@ -115,12 +117,14 @@ static SDispatchResult dispatch_move_window(std::string arg) {
     const PHTVIEW cursor_view = ht_manager->get_view_from_cursor();
     if (cursor_view == nullptr)
         return {.success = false, .error = "cursor_view is null"};
-    cursor_view->move(arg, true);
     if (arg == "in") {
         return change_layer("-1", true);
     } if (arg == "out") {
         return change_layer("+1", true);
     }
+    if (arg != "up" && arg != "down" && arg != "left" && arg != "right")
+        return {.success = false, .error = "invalid arg"};
+    cursor_view->move(arg, true);
     return {};
 }
 
@@ -158,6 +162,8 @@ static void set_layer(PHTVIEW view, int new_layer) {
 static SDispatchResult change_layer(std::string arg, bool move_window) {
     if (ht_manager == nullptr)
         return {.success = false, .error = "ht_manager is null"};
+    if (arg.empty())
+        return {.success = false, .error = "invalid arg"};
 
     const PHTVIEW cursor_view = ht_manager->get_view_from_cursor();
     if (cursor_view == nullptr)
@@ -189,12 +195,11 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         return {.success = false, .error = "active workspace not in layout"};
 
     const int original_layer = cursor_view->layout->layer;
-    const std::string layer_arg = arg.empty() ? "+1" : arg;
     int resulting_layer = original_layer;
-    if (layer_arg[0] == '+' || layer_arg[0] == '-') {
-        resulting_layer += std::stoi(layer_arg);
+    if (arg[0] == '+' || arg[0] == '-') {
+        resulting_layer += std::stoi(arg);
     } else {
-        resulting_layer = std::stoi(layer_arg);
+        resulting_layer = std::stoi(arg);
     }
 
     int source_cell = 0;
@@ -220,7 +225,9 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     const int needed_layers = std::max(1, (int)(monitor_workspaces.size() + ws_per_layer - 1) / ws_per_layer);
     const int effective_layers = std::max(configured_layers, needed_layers);
 
+    // if resulting offset doesn't fit in boundaries
     if (resulting_layer >= effective_layers || resulting_layer < 0) {
+        // Don't do anything if next is invalid and grid:loop_layers is disabled
         if (!LOOP_LAYERS)
             return {};
         resulting_layer = ((resulting_layer % effective_layers) + effective_layers) % effective_layers;
@@ -229,23 +236,18 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     WORKSPACEID target_ws_id = WORKSPACE_INVALID;
     const int target_slot = resulting_layer * ws_per_layer + source_cell;
 
+    // Preserve the currently visible grid before changing layers, otherwise a
+    // rebuild may auto-pack workspaces and make the same cell point elsewhere.
     for (const auto& [ws_id, ws_layout] : cursor_view->layout->overview_layout) {
         const int slot = original_layer * ws_per_layer + ws_layout.y * COLS + ws_layout.x;
         grid_layout->pin_workspace_to_slot(ws_id, slot);
     }
 
-    if (cursor_view->active) {
-        set_layer(cursor_view, resulting_layer);
-        cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-        g_pHyprRenderer->damageMonitor(monitor);
-        g_pCompositor->scheduleFrameForMonitor(monitor);
-        grid_layout->last_layer_cell = source_cell;
-        return {};
-    }
-
     set_layer(cursor_view, resulting_layer);
     cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
     target_ws_id = cursor_view->layout->get_ws_id_from_xy(source_cell % COLS, source_cell / COLS);
+
+    PHLWORKSPACE target_workspace = nullptr;
 
     if (target_ws_id == WORKSPACE_INVALID) {
         WORKSPACEID next_id = 1;
@@ -264,31 +266,40 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
 
         grid_layout->pin_workspace_to_slot(next_id, target_slot);
         target_ws_id = next_id;
+        // createNewWorkspace can return before overview_layout sees the new ws,
+        // so keep the returned pointer instead of looking it up immediately.
+        target_workspace = new_workspace;
     } else {
         grid_layout->pin_workspace_to_slot(target_ws_id, target_slot);
+        target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
     }
 
     cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    if (target_workspace == nullptr)
+        target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
+
+    if (target_workspace == nullptr) {
+        set_layer(cursor_view, original_layer);
+        cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+        return {};
+    }
+
+    if (move_window) {
+        const PHLWINDOW hovered_window = ht_manager->get_window_from_cursor();
+        if (hovered_window != nullptr)
+            g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, target_workspace);
+    }
+
+    monitor->changeWorkspace(target_workspace);
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    g_pHyprRenderer->damageMonitor(monitor);
+    g_pCompositor->scheduleFrameForMonitor(monitor);
+
     if (!cursor_view->active) {
-        const PHLWORKSPACE target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
-        if (target_workspace == nullptr) {
-            set_layer(cursor_view, original_layer);
-            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-            return {};
-        }
-
-        if (move_window) {
-            const PHLWINDOW hovered_window = ht_manager->get_window_from_cursor();
-            if (hovered_window != nullptr)
-                g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, target_workspace);
-        }
-
-        monitor->changeWorkspace(target_workspace);
         cursor_view->layout->on_move(source_ws_id, target_ws_id);
         return {};
     }
 
-    cursor_view->move_id(target_ws_id, move_window);
     return {};
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -506,9 +506,16 @@ static void register_monitors(bool reset_existing_views) {
         }
     }
 
-    // Purge views whose monitor no longer exists and could not be reconnected.
+    // Purge views whose monitor no longer exists.  Keep views with a known
+    // monitor_name around – the monitor may just be asleep (DPMS) and will
+    // reconnect later.  This prevents workspace loss across wake cycles.
     std::erase_if(ht_manager->views, [](const PHTVIEW& view) {
-        return view == nullptr || view->get_monitor() == nullptr;
+        if (view == nullptr)
+            return true;
+        if (view->get_monitor() != nullptr)
+            return false;
+        // Don't erase views whose monitor_name might still reconnect.
+        return view->monitor_name.empty();
     });
 
     for (const PHLMONITOR& monitor : g_pCompositor->m_monitors) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include <hyprutils/math/Vector2D.hpp>
 
 #include <algorithm>
+#include <fstream>
 
 #include "config.hpp"
 #include "globals.hpp"
@@ -61,6 +62,12 @@ static SDispatchResult dispatch_if(std::string arg, bool is_active) {
     );
 
     return res;
+}
+
+static void debug_setlayer_log(const std::string& message) {
+    std::ofstream log_file("/tmp/hyprtasking-setlayer.log", std::ios::app);
+    if (log_file.is_open())
+        log_file << message << '\n';
 }
 
 static SDispatchResult dispatch_if_not_active(std::string arg) {
@@ -171,14 +178,6 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     const int LAYERS = HTConfig::value<Hyprlang::INT>("grid:layers");
     const int LOOP_LAYERS = HTConfig::value<Hyprlang::INT>("grid:loop_layers");
     const int ws_per_layer = std::max(1, ROWS * COLS);
-    const int original_layer = cursor_view->layout->layer;
-
-    int resulting_layer = original_layer;
-    if (arg[0] == '+' || arg[0] == '-') {
-        resulting_layer += std::stoi(arg);
-    } else {
-        resulting_layer = std::stoi(arg);
-    }
 
     const PHLMONITOR monitor = cursor_view->get_monitor();
     if (monitor == nullptr)
@@ -188,47 +187,125 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         return {.success = false, .error = "active_workspace is null"};
     const WORKSPACEID source_ws_id = active_workspace->m_id;
 
+    if (!cursor_view->active)
+        cursor_view->layout->init_position();
+
     cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
     const auto active_it = cursor_view->layout->overview_layout.find(source_ws_id);
-    if (active_it == cursor_view->layout->overview_layout.end())
+    if (active_it == cursor_view->layout->overview_layout.end() && !cursor_view->active)
         return {.success = false, .error = "active workspace not in layout"};
 
-    const int source_cell = active_it->second.y * COLS + active_it->second.x;
+    const int original_layer = cursor_view->layout->layer;
+    const std::string layer_arg = arg.empty() ? "+1" : arg;
+    int resulting_layer = original_layer;
+    if (layer_arg[0] == '+' || layer_arg[0] == '-') {
+        resulting_layer += std::stoi(layer_arg);
+    } else {
+        resulting_layer = std::stoi(layer_arg);
+    }
+
+    int source_cell = 0;
+    if (active_it != cursor_view->layout->overview_layout.end()) {
+        source_cell = active_it->second.y * COLS + active_it->second.x;
+    } else {
+        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
+        if (grid_layout != nullptr)
+            source_cell = grid_layout->last_layer_cell;
+        debug_setlayer_log(std::format(
+            "setlayer active_source_fallback monitor={} source_ws={} source_cell={}",
+            monitor->m_name,
+            source_ws_id,
+            source_cell
+        ));
+    }
 
     const std::vector<PHLWORKSPACE> monitor_workspaces = cursor_view->layout->get_monitor_workspaces();
     if (monitor_workspaces.empty())
         return {};
 
+    const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
+    if (grid_layout == nullptr)
+        return {.success = false, .error = "grid layout is null"};
+
+    grid_layout->last_layer_cell = source_cell;
+
     const int configured_layers = std::max(1, LAYERS);
     const int needed_layers = std::max(1, (int)(monitor_workspaces.size() + ws_per_layer - 1) / ws_per_layer);
-    // Allow navigation up to configured_layers even if they're empty
-    const int effective_layers = std::max({configured_layers, needed_layers, resulting_layer + 1});
+    const int effective_layers = std::max(configured_layers, needed_layers);
 
     if (resulting_layer >= effective_layers || resulting_layer < 0) {
         if (!LOOP_LAYERS)
             return {};
-        resulting_layer = (resulting_layer + effective_layers) % effective_layers;
+        resulting_layer = ((resulting_layer % effective_layers) + effective_layers) % effective_layers;
+    }
+
+    Log::logger->log(
+        LOG,
+        "[Hyprtasking] setlayer arg={} monitor={} active={} source_ws={} original_layer={} target_layer={} source_cell={} effective_layers={} active_view={} navigating={}",
+        layer_arg,
+        monitor->m_name,
+        active_workspace->m_id,
+        source_ws_id,
+        original_layer,
+        resulting_layer,
+        source_cell,
+        effective_layers,
+        cursor_view->active,
+        cursor_view->navigating
+    );
+    debug_setlayer_log(std::format(
+        "setlayer arg={} monitor={} active={} source_ws={} original_layer={} target_layer={} source_cell={} effective_layers={} active_view={} navigating={}",
+        layer_arg,
+        monitor->m_name,
+        active_workspace->m_id,
+        source_ws_id,
+        original_layer,
+        resulting_layer,
+        source_cell,
+        effective_layers,
+        cursor_view->active,
+        cursor_view->navigating
+    ));
+
+    WORKSPACEID target_ws_id = WORKSPACE_INVALID;
+    const int target_slot = resulting_layer * ws_per_layer + source_cell;
+
+    for (const auto& [ws_id, ws_layout] : cursor_view->layout->overview_layout) {
+        const int slot = original_layer * ws_per_layer + ws_layout.y * COLS + ws_layout.x;
+        grid_layout->pin_workspace_to_slot(ws_id, slot);
+    }
+
+    if (cursor_view->active) {
+        set_layer(cursor_view, resulting_layer);
+        cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+        g_pHyprRenderer->damageMonitor(monitor);
+        g_pCompositor->scheduleFrameForMonitor(monitor);
+        grid_layout->last_layer_cell = source_cell;
+        debug_setlayer_log(std::format("setlayer active_layer_only target_layer={} target_slot={}", resulting_layer, target_slot));
+        return {};
     }
 
     set_layer(cursor_view, resulting_layer);
     cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    target_ws_id = cursor_view->layout->get_ws_id_from_xy(source_cell % COLS, source_cell / COLS);
 
-    WORKSPACEID target_ws_id = WORKSPACE_INVALID;
-    for (const auto& [ws_id, ws_layout] : cursor_view->layout->overview_layout) {
-        if (ws_layout.y * COLS + ws_layout.x == source_cell) {
-            target_ws_id = ws_id;
-            break;
-        }
-    }
+    Log::logger->log(
+        LOG,
+        "[Hyprtasking] setlayer target lookup slot={} x={} y={} found_ws={}",
+        target_slot,
+        source_cell % COLS,
+        source_cell / COLS,
+        target_ws_id
+    );
+    debug_setlayer_log(std::format(
+        "setlayer target_lookup slot={} x={} y={} found_ws={}",
+        target_slot,
+        source_cell % COLS,
+        source_cell / COLS,
+        target_ws_id
+    ));
 
     if (target_ws_id == WORKSPACE_INVALID) {
-        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
-        if (grid_layout == nullptr) {
-            set_layer(cursor_view, original_layer);
-            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-            return {};
-        }
-
         WORKSPACEID next_id = 1;
         for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
             if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
@@ -243,11 +320,40 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
             return {};
         }
 
-        const int target_slot = resulting_layer * ws_per_layer + source_cell;
         grid_layout->pin_workspace_to_slot(next_id, target_slot);
         target_ws_id = next_id;
+        Log::logger->log(LOG, "[Hyprtasking] setlayer created workspace {} for slot {}", target_ws_id, target_slot);
+        debug_setlayer_log(std::format("setlayer created workspace={} slot={}", target_ws_id, target_slot));
+    } else {
+        grid_layout->pin_workspace_to_slot(target_ws_id, target_slot);
+        Log::logger->log(LOG, "[Hyprtasking] setlayer pinned existing workspace {} to slot {}", target_ws_id, target_slot);
+        debug_setlayer_log(std::format("setlayer pinned workspace={} slot={}", target_ws_id, target_slot));
     }
 
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    if (!cursor_view->active) {
+        const PHLWORKSPACE target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
+        if (target_workspace == nullptr) {
+            set_layer(cursor_view, original_layer);
+            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+            return {};
+        }
+
+        if (move_window) {
+            const PHLWINDOW hovered_window = ht_manager->get_window_from_cursor();
+            if (hovered_window != nullptr)
+                g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, target_workspace);
+        }
+
+        monitor->changeWorkspace(target_workspace);
+        cursor_view->layout->on_move(source_ws_id, target_ws_id);
+        Log::logger->log(LOG, "[Hyprtasking] setlayer changed closed view to workspace {}", target_ws_id);
+        debug_setlayer_log(std::format("setlayer closed_change target_ws={}", target_ws_id));
+        return {};
+    }
+
+    Log::logger->log(LOG, "[Hyprtasking] setlayer moving active view to workspace {}", target_ws_id);
+    debug_setlayer_log(std::format("setlayer active_move target_ws={}", target_ws_id));
     cursor_view->move_id(target_ws_id, move_window);
     return {};
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -174,10 +174,8 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
 
     int resulting_layer = original_layer;
     if (arg[0] == '+' || arg[0] == '-') {
-        // relative jump
         resulting_layer += std::stoi(arg);
     } else {
-        // absolute jump
         resulting_layer = std::stoi(arg);
     }
 
@@ -189,18 +187,15 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         return {.success = false, .error = "active_workspace is null"};
     const WORKSPACEID source_ws_id = active_workspace->m_id;
 
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    const auto active_it = cursor_view->layout->overview_layout.find(source_ws_id);
+    if (active_it == cursor_view->layout->overview_layout.end())
+        return {.success = false, .error = "active workspace not in layout"};
+
+    const int target_cell = active_it->second.y * COLS + active_it->second.x;
+
     const std::vector<PHLWORKSPACE> monitor_workspaces = cursor_view->layout->get_monitor_workspaces();
     if (monitor_workspaces.empty())
-        return {};
-
-    int source_index = -1;
-    for (size_t i = 0; i < monitor_workspaces.size(); i++) {
-        if (monitor_workspaces[i] != nullptr && monitor_workspaces[i]->m_id == source_ws_id) {
-            source_index = (int)i;
-            break;
-        }
-    }
-    if (source_index < 0)
         return {};
 
     const int configured_layers = std::max(1, LAYERS);
@@ -216,7 +211,6 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         resulting_layer = (resulting_layer + effective_layers) % effective_layers;
     }
 
-    const int target_cell = source_index % ws_per_layer;
     const int target_page_start = resulting_layer * ws_per_layer;
     if (target_page_start >= (int)monitor_workspaces.size())
         return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -476,14 +476,42 @@ static void register_monitors(bool reset_existing_views) {
     if (ht_manager == nullptr)
         return;
 
-    // Purge views whose monitor no longer exists to prevent unbounded growth
-    // after monitor disconnect / idle / reinitialization.
+    // Reconnect orphaned views after DPMS/monitor reconnect (m_id changes,
+    // but m_name is stable across cycles).
+    for (const PHLMONITOR& monitor : g_pCompositor->m_monitors) {
+        if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
+            continue;
+
+        for (PHTVIEW view : ht_manager->views) {
+            if (view == nullptr)
+                continue;
+            if (view->get_monitor() != nullptr)
+                continue; // still attached to a live monitor
+
+            // View exists but monitor is gone – check if the *same* physical
+            // monitor is reconnecting under a new id.  m_name (e.g. "DP-1")
+            // is stable across DPMS cycles, unlike m_id.
+            if (view->monitor_name == monitor->m_name) {
+                view->monitor_id = monitor->m_id;
+                view->monitor_name = monitor->m_name;
+                view->reset_for_monitor_change();
+                Log::logger->log(
+                    LOG,
+                    "[Hyprtasking] Reconnected view for monitor {} with new id {}",
+                    monitor->m_name,
+                    monitor->m_id
+                );
+                break;
+            }
+        }
+    }
+
+    // Purge views whose monitor no longer exists and could not be reconnected.
     std::erase_if(ht_manager->views, [](const PHTVIEW& view) {
         return view == nullptr || view->get_monitor() == nullptr;
     });
 
     for (const PHLMONITOR& monitor : g_pCompositor->m_monitors) {
-        // Skip monitors that haven't finished initializing
         if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)
             continue;
 
@@ -495,7 +523,10 @@ static void register_monitors(bool reset_existing_views) {
                 view->layout->init_position();
             continue;
         }
-        ht_manager->views.push_back(makeShared<HTView>(monitor->m_id));
+
+        auto new_view = makeShared<HTView>(monitor->m_id);
+        new_view->monitor_name = monitor->m_name;
+        ht_manager->views.push_back(new_view);
 
         Log::logger->log(
             LOG,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,18 +253,21 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     PHLWORKSPACE target_workspace = nullptr;
 
     if (target_ws_id == WORKSPACE_INVALID) {
-        const PHLWORKSPACE new_workspace = create_workspace_for_monitor(monitor);
-        if (new_workspace == nullptr) {
-            set_layer(cursor_view, original_layer);
-            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-            return {};
+        if (!move_window && can_reuse_empty_workspace(active_workspace, monitor)) {
+            target_workspace = active_workspace;
+        } else {
+            target_workspace = create_workspace_for_monitor(monitor);
+            if (target_workspace == nullptr) {
+                set_layer(cursor_view, original_layer);
+                cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+                return {};
+            }
         }
 
-        grid_layout->pin_workspace_to_slot(new_workspace->m_id, target_slot);
-        target_ws_id = new_workspace->m_id;
-        // createNewWorkspace can return before overview_layout sees the new ws,
-        // so keep the returned pointer instead of looking it up immediately.
-        target_workspace = new_workspace;
+        grid_layout->pin_workspace_to_slot(target_workspace->m_id, target_slot);
+        target_ws_id = target_workspace->m_id;
+        // Reused or newly created empty workspaces may not be in
+        // overview_layout yet, so keep the pointer instead of looking it up.
     } else {
         grid_layout->pin_workspace_to_slot(target_ws_id, target_slot);
         target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -223,6 +223,8 @@ static void apply_layer_change(
     else
         monitor->changeWorkspace(target_workspace);
 
+    cursor_view->mark_workspace(target_workspace->m_id);
+
     cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
     g_pHyprRenderer->damageMonitor(monitor);
     g_pCompositor->scheduleFrameForMonitor(monitor);
@@ -406,9 +408,9 @@ static void on_mouse_button(IPointer::SButtonEvent e, Event::SCallbackInfo& info
     const unsigned int select_button = static_cast<Hyprlang::INT>(HTConfig::value("select_button"));
 
     if (pressed && e.button == drag_button) {
-        info.cancelled = ht_manager->start_window_drag();
+        info.cancelled = ht_manager->mark_workspace();
     } else if (!pressed && e.button == drag_button) {
-        info.cancelled = ht_manager->end_window_drag();
+        info.cancelled = false;
     } else if (pressed && e.button == select_button) {
         info.cancelled = ht_manager->exit_to_workspace();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,8 @@
 #include <hyprutils/math/Box.hpp>
 #include <hyprutils/math/Vector2D.hpp>
 
+#include <algorithm>
+
 #include "config.hpp"
 #include "globals.hpp"
 #include "overview.hpp"
@@ -167,7 +169,7 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
     const int LAYERS = HTConfig::value<Hyprlang::INT>("grid:layers");
     const int LOOP_LAYERS = HTConfig::value<Hyprlang::INT>("grid:loop_layers");
-    const int ws_per_layer = ROWS*COLS;
+    const int ws_per_layer = std::max(1, ROWS * COLS);
     const int original_layer = cursor_view->layout->layer;
 
     int resulting_layer = original_layer;
@@ -187,25 +189,43 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         return {.success = false, .error = "active_workspace is null"};
     const WORKSPACEID source_ws_id = active_workspace->m_id;
 
-    const int layer_delta = resulting_layer - original_layer;
-    WORKSPACEID target_ws_id = source_ws_id + layer_delta * ws_per_layer;
+    const std::vector<PHLWORKSPACE> monitor_workspaces = cursor_view->layout->get_monitor_workspaces();
+    if (monitor_workspaces.empty())
+        return {};
 
-    // if resulting offset doesn't fit in boundaries
-    if (resulting_layer >= LAYERS || resulting_layer < 0) {
-        // Don't do anything if next is invalid and grid:loop_layers is disabled
-        if (!LOOP_LAYERS) {
-            return {};
+    int source_index = -1;
+    for (size_t i = 0; i < monitor_workspaces.size(); i++) {
+        if (monitor_workspaces[i] != nullptr && monitor_workspaces[i]->m_id == source_ws_id) {
+            source_index = (int)i;
+            break;
         }
-
-        if (resulting_layer < 0) {
-            resulting_layer = LAYERS - 1;
-        } else if (resulting_layer >= LAYERS) {
-            resulting_layer = 0;
-        }
-        target_ws_id = cursor_view->monitor_id * ws_per_layer * LAYERS + // Monitor
-                       ws_per_layer * resulting_layer +                  // Layer
-                       (source_ws_id - 1) % ws_per_layer + 1;            // X and Y of a workspace
     }
+    if (source_index < 0)
+        return {};
+
+    const int configured_layers = std::max(1, LAYERS);
+    const int needed_layers = std::max(
+        1,
+        (int)(monitor_workspaces.size() + ws_per_layer - 1) / ws_per_layer
+    );
+    const int effective_layers = std::max(configured_layers, needed_layers);
+
+    if (resulting_layer >= effective_layers || resulting_layer < 0) {
+        if (!LOOP_LAYERS)
+            return {};
+        resulting_layer = (resulting_layer + effective_layers) % effective_layers;
+    }
+
+    const int target_cell = source_index % ws_per_layer;
+    const int target_page_start = resulting_layer * ws_per_layer;
+    if (target_page_start >= (int)monitor_workspaces.size())
+        return {};
+
+    const int target_index = std::min(
+        target_page_start + target_cell,
+        (int)monitor_workspaces.size() - 1
+    );
+    const WORKSPACEID target_ws_id = monitor_workspaces[target_index]->m_id;
 
     set_layer(cursor_view, resulting_layer);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "layout/grid.hpp"
 #include "overview.hpp"
 #include "types.hpp"
+#include "workspace.hpp"
 
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
     return HYPRLAND_API_VERSION;
@@ -230,7 +231,9 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         // Don't do anything if next is invalid and grid:loop_layers is disabled
         if (!LOOP_LAYERS)
             return {};
-        resulting_layer = ((resulting_layer % effective_layers) + effective_layers) % effective_layers;
+        resulting_layer %= effective_layers;
+        if (resulting_layer < 0)
+            resulting_layer += effective_layers;
     }
 
     WORKSPACEID target_ws_id = WORKSPACE_INVALID;
@@ -250,22 +253,15 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     PHLWORKSPACE target_workspace = nullptr;
 
     if (target_ws_id == WORKSPACE_INVALID) {
-        WORKSPACEID next_id = 1;
-        for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-            if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
-                next_id = ws->m_id + 1;
-            }
-        }
-
-        const PHLWORKSPACE new_workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+        const PHLWORKSPACE new_workspace = create_workspace_for_monitor(monitor);
         if (new_workspace == nullptr) {
             set_layer(cursor_view, original_layer);
             cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
             return {};
         }
 
-        grid_layout->pin_workspace_to_slot(next_id, target_slot);
-        target_ws_id = next_id;
+        grid_layout->pin_workspace_to_slot(new_workspace->m_id, target_slot);
+        target_ws_id = new_workspace->m_id;
         // createNewWorkspace can return before overview_layout sees the new ws,
         // so keep the returned pointer instead of looking it up immediately.
         target_workspace = new_workspace;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,6 +253,8 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     PHLWORKSPACE target_workspace = nullptr;
 
     if (target_ws_id == WORKSPACE_INVALID) {
+        // Avoid growing workspace IDs when just hopping between empty cells.
+        // If the current workspace is empty, move that workspace to the target.
         if (!move_window && can_reuse_empty_workspace(active_workspace, monitor)) {
             target_workspace = active_workspace;
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,6 @@
 #include <hyprutils/math/Vector2D.hpp>
 
 #include <algorithm>
-#include <fstream>
 
 #include "config.hpp"
 #include "globals.hpp"
@@ -62,12 +61,6 @@ static SDispatchResult dispatch_if(std::string arg, bool is_active) {
     );
 
     return res;
-}
-
-static void debug_setlayer_log(const std::string& message) {
-    std::ofstream log_file("/tmp/hyprtasking-setlayer.log", std::ios::app);
-    if (log_file.is_open())
-        log_file << message << '\n';
 }
 
 static SDispatchResult dispatch_if_not_active(std::string arg) {
@@ -211,12 +204,6 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
         if (grid_layout != nullptr)
             source_cell = grid_layout->last_layer_cell;
-        debug_setlayer_log(std::format(
-            "setlayer active_source_fallback monitor={} source_ws={} source_cell={}",
-            monitor->m_name,
-            source_ws_id,
-            source_cell
-        ));
     }
 
     const std::vector<PHLWORKSPACE> monitor_workspaces = cursor_view->layout->get_monitor_workspaces();
@@ -239,34 +226,6 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         resulting_layer = ((resulting_layer % effective_layers) + effective_layers) % effective_layers;
     }
 
-    Log::logger->log(
-        LOG,
-        "[Hyprtasking] setlayer arg={} monitor={} active={} source_ws={} original_layer={} target_layer={} source_cell={} effective_layers={} active_view={} navigating={}",
-        layer_arg,
-        monitor->m_name,
-        active_workspace->m_id,
-        source_ws_id,
-        original_layer,
-        resulting_layer,
-        source_cell,
-        effective_layers,
-        cursor_view->active,
-        cursor_view->navigating
-    );
-    debug_setlayer_log(std::format(
-        "setlayer arg={} monitor={} active={} source_ws={} original_layer={} target_layer={} source_cell={} effective_layers={} active_view={} navigating={}",
-        layer_arg,
-        monitor->m_name,
-        active_workspace->m_id,
-        source_ws_id,
-        original_layer,
-        resulting_layer,
-        source_cell,
-        effective_layers,
-        cursor_view->active,
-        cursor_view->navigating
-    ));
-
     WORKSPACEID target_ws_id = WORKSPACE_INVALID;
     const int target_slot = resulting_layer * ws_per_layer + source_cell;
 
@@ -281,29 +240,12 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         g_pHyprRenderer->damageMonitor(monitor);
         g_pCompositor->scheduleFrameForMonitor(monitor);
         grid_layout->last_layer_cell = source_cell;
-        debug_setlayer_log(std::format("setlayer active_layer_only target_layer={} target_slot={}", resulting_layer, target_slot));
         return {};
     }
 
     set_layer(cursor_view, resulting_layer);
     cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
     target_ws_id = cursor_view->layout->get_ws_id_from_xy(source_cell % COLS, source_cell / COLS);
-
-    Log::logger->log(
-        LOG,
-        "[Hyprtasking] setlayer target lookup slot={} x={} y={} found_ws={}",
-        target_slot,
-        source_cell % COLS,
-        source_cell / COLS,
-        target_ws_id
-    );
-    debug_setlayer_log(std::format(
-        "setlayer target_lookup slot={} x={} y={} found_ws={}",
-        target_slot,
-        source_cell % COLS,
-        source_cell / COLS,
-        target_ws_id
-    ));
 
     if (target_ws_id == WORKSPACE_INVALID) {
         WORKSPACEID next_id = 1;
@@ -322,12 +264,8 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
 
         grid_layout->pin_workspace_to_slot(next_id, target_slot);
         target_ws_id = next_id;
-        Log::logger->log(LOG, "[Hyprtasking] setlayer created workspace {} for slot {}", target_ws_id, target_slot);
-        debug_setlayer_log(std::format("setlayer created workspace={} slot={}", target_ws_id, target_slot));
     } else {
         grid_layout->pin_workspace_to_slot(target_ws_id, target_slot);
-        Log::logger->log(LOG, "[Hyprtasking] setlayer pinned existing workspace {} to slot {}", target_ws_id, target_slot);
-        debug_setlayer_log(std::format("setlayer pinned workspace={} slot={}", target_ws_id, target_slot));
     }
 
     cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
@@ -347,13 +285,9 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
 
         monitor->changeWorkspace(target_workspace);
         cursor_view->layout->on_move(source_ws_id, target_ws_id);
-        Log::logger->log(LOG, "[Hyprtasking] setlayer changed closed view to workspace {}", target_ws_id);
-        debug_setlayer_log(std::format("setlayer closed_change target_ws={}", target_ws_id));
         return {};
     }
 
-    Log::logger->log(LOG, "[Hyprtasking] setlayer moving active view to workspace {}", target_ws_id);
-    debug_setlayer_log(std::format("setlayer active_move target_ws={}", target_ws_id));
     cursor_view->move_id(target_ws_id, move_window);
     return {};
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,17 +217,15 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     }
 
     const int target_cell = source_index % ws_per_layer;
-    const int target_page_start = resulting_layer * ws_per_layer;
-    if (target_page_start >= (int)monitor_workspaces.size())
-        return {};
-
-    const int target_index = std::min(
-        target_page_start + target_cell,
-        (int)monitor_workspaces.size() - 1
-    );
-    const WORKSPACEID target_ws_id = monitor_workspaces[target_index]->m_id;
 
     set_layer(cursor_view, resulting_layer);
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+
+    const int target_x = target_cell % COLS;
+    const int target_y = target_cell / COLS;
+    const WORKSPACEID target_ws_id = cursor_view->layout->get_ws_id_from_xy(target_x, target_y);
+    if (target_ws_id == WORKSPACE_INVALID)
+        return {};
 
     cursor_view->move_id(target_ws_id, move_window);
     return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,7 @@
 
 #include "config.hpp"
 #include "globals.hpp"
+#include "layout/grid.hpp"
 #include "overview.hpp"
 #include "types.hpp"
 
@@ -192,18 +193,16 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     if (active_it == cursor_view->layout->overview_layout.end())
         return {.success = false, .error = "active workspace not in layout"};
 
-    const int target_cell = active_it->second.y * COLS + active_it->second.x;
+    const int source_cell = active_it->second.y * COLS + active_it->second.x;
 
     const std::vector<PHLWORKSPACE> monitor_workspaces = cursor_view->layout->get_monitor_workspaces();
     if (monitor_workspaces.empty())
         return {};
 
     const int configured_layers = std::max(1, LAYERS);
-    const int needed_layers = std::max(
-        1,
-        (int)(monitor_workspaces.size() + ws_per_layer - 1) / ws_per_layer
-    );
-    const int effective_layers = std::max(configured_layers, needed_layers);
+    const int needed_layers = std::max(1, (int)(monitor_workspaces.size() + ws_per_layer - 1) / ws_per_layer);
+    // Allow navigation up to configured_layers even if they're empty
+    const int effective_layers = std::max({configured_layers, needed_layers, resulting_layer + 1});
 
     if (resulting_layer >= effective_layers || resulting_layer < 0) {
         if (!LOOP_LAYERS)
@@ -211,17 +210,43 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         resulting_layer = (resulting_layer + effective_layers) % effective_layers;
     }
 
-    const int target_page_start = resulting_layer * ws_per_layer;
-    if (target_page_start >= (int)monitor_workspaces.size())
-        return {};
-
-    const int target_index = std::min(
-        target_page_start + target_cell,
-        (int)monitor_workspaces.size() - 1
-    );
-    const WORKSPACEID target_ws_id = monitor_workspaces[target_index]->m_id;
-
     set_layer(cursor_view, resulting_layer);
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+
+    WORKSPACEID target_ws_id = WORKSPACE_INVALID;
+    for (const auto& [ws_id, ws_layout] : cursor_view->layout->overview_layout) {
+        if (ws_layout.y * COLS + ws_layout.x == source_cell) {
+            target_ws_id = ws_id;
+            break;
+        }
+    }
+
+    if (target_ws_id == WORKSPACE_INVALID) {
+        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(cursor_view->layout);
+        if (grid_layout == nullptr) {
+            set_layer(cursor_view, original_layer);
+            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+            return {};
+        }
+
+        WORKSPACEID next_id = 1;
+        for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+            if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
+                next_id = ws->m_id + 1;
+            }
+        }
+
+        const PHLWORKSPACE new_workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+        if (new_workspace == nullptr) {
+            set_layer(cursor_view, original_layer);
+            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+            return {};
+        }
+
+        const int target_slot = resulting_layer * ws_per_layer + source_cell;
+        grid_layout->pin_workspace_to_slot(next_id, target_slot);
+        target_ws_id = next_id;
+    }
 
     cursor_view->move_id(target_ws_id, move_window);
     return {};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,40 +92,32 @@ static SDispatchResult dispatch_toggle_view(std::string arg) {
     return {};
 }
 
-// Forward declaration
 static SDispatchResult change_layer(std::string arg, bool move_window);
+static SDispatchResult dispatch_move_impl(std::string arg, bool move_window);
 
 static SDispatchResult dispatch_move(std::string arg) {
-    if (ht_manager == nullptr)
-        return {.success = false, .error = "ht_manager is null"};
-    const PHTVIEW cursor_view = ht_manager->get_view_from_cursor();
-    if (cursor_view == nullptr)
-        return {.success = false, .error = "cursor_view is null"};
-    if (arg == "in") {
-        return change_layer("-1", false);
-    } if (arg == "out") {
-        return change_layer("+1", false);
-    }
-    if (arg != "up" && arg != "down" && arg != "left" && arg != "right")
-        return {.success = false, .error = "invalid arg"};
-    cursor_view->move(arg, false);
-    return {};
+    return dispatch_move_impl(arg, false);
 }
 
 static SDispatchResult dispatch_move_window(std::string arg) {
+    return dispatch_move_impl(arg, true);
+}
+
+static SDispatchResult dispatch_move_impl(std::string arg, bool move_window) {
     if (ht_manager == nullptr)
         return {.success = false, .error = "ht_manager is null"};
     const PHTVIEW cursor_view = ht_manager->get_view_from_cursor();
     if (cursor_view == nullptr)
         return {.success = false, .error = "cursor_view is null"};
     if (arg == "in") {
-        return change_layer("-1", true);
-    } if (arg == "out") {
-        return change_layer("+1", true);
+        return change_layer("-1", move_window);
+    }
+    if (arg == "out") {
+        return change_layer("+1", move_window);
     }
     if (arg != "up" && arg != "down" && arg != "left" && arg != "right")
         return {.success = false, .error = "invalid arg"};
-    cursor_view->move(arg, true);
+    cursor_view->move(arg, move_window);
     return {};
 }
 
@@ -133,21 +125,7 @@ static void set_layer(PHTVIEW view, int new_layer) {
     if (view == nullptr)
         return;
 
-    // HACK: Prevent no focus when closing the view
-    // Makes layers less responsive and less buggy
-    // Ideally we would wait for it to close and then update
-    // Or update the destination as the offset is changing
-    // If you wanna fix this, then test it
-    // on a multimonitor setup with this command:
-    //   hyprctl dispatch --batch 'dispatch hyprtasking:setlayer -1;
-    //   dispatch hyprtasking:move left;
-    //   dispatch hyprtasking:toggle cursor;
-    //   dispatch hyprtasking:setlayer -1;
-    //   dispatch hyprtasking:toggle cursor;
-    //   dispatch hyprtasking:toggle cursor;
-    //   dispatch hyprtasking:move down;
-    //   dispatch hyprtasking:setlayer +1;
-    //   dispatch hyprtasking:toggle cursor'
+    // Avoid focus loss while a view is closing.
     if (view->closing)
         return;
     Log::logger->log(
@@ -158,6 +136,99 @@ static void set_layer(PHTVIEW view, int new_layer) {
         new_layer
     );
     view->layout->layer = new_layer;
+}
+
+static bool calculate_target_layer(
+    std::string arg,
+    int original_layer,
+    int effective_layers,
+    bool loop_layers,
+    int& resulting_layer
+) {
+    resulting_layer = original_layer;
+    if (arg[0] == '+' || arg[0] == '-')
+        resulting_layer += std::stoi(arg);
+    else
+        resulting_layer = std::stoi(arg);
+
+    if (resulting_layer >= 0 && resulting_layer < effective_layers)
+        return true;
+    if (!loop_layers)
+        return false;
+
+    resulting_layer %= effective_layers;
+    if (resulting_layer < 0)
+        resulting_layer += effective_layers;
+    return true;
+}
+
+static PHLWORKSPACE find_or_create_target_workspace(
+    PHTVIEW cursor_view,
+    PHLMONITOR monitor,
+    SP<HTLayoutGrid> grid_layout,
+    int source_cell,
+    int target_slot,
+    int resulting_layer,
+    int original_layer,
+    int cols
+) {
+    set_layer(cursor_view, resulting_layer);
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+
+    WORKSPACEID target_ws_id = cursor_view->layout->get_ws_id_from_xy(source_cell % cols, source_cell / cols);
+    PHLWORKSPACE target_workspace = nullptr;
+
+    if (target_ws_id == WORKSPACE_INVALID) {
+        target_workspace = create_workspace_for_monitor(monitor);
+        if (target_workspace == nullptr) {
+            set_layer(cursor_view, original_layer);
+            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+            return nullptr;
+        }
+        target_ws_id = target_workspace->m_id;
+    } else {
+        target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
+    }
+
+    grid_layout->pin_workspace_to_slot(target_ws_id, target_slot);
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+
+    if (target_workspace == nullptr)
+        target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
+
+    if (target_workspace != nullptr)
+        return target_workspace;
+
+    set_layer(cursor_view, original_layer);
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    return nullptr;
+}
+
+static void apply_layer_change(
+    PHTVIEW cursor_view,
+    PHLMONITOR monitor,
+    WORKSPACEID source_ws_id,
+    PHLWORKSPACE target_workspace,
+    bool move_window
+) {
+    if (move_window) {
+        const PHLWINDOW hovered_window = ht_manager->get_window_from_cursor();
+        if (hovered_window != nullptr)
+            g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, target_workspace);
+    }
+
+    const PHLMONITOR ws_monitor = g_pCompositor->getMonitorFromID(target_workspace->monitorID());
+    if (ws_monitor != nullptr)
+        ws_monitor->changeWorkspace(target_workspace);
+    else
+        monitor->changeWorkspace(target_workspace);
+
+    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    g_pHyprRenderer->damageMonitor(monitor);
+    g_pCompositor->scheduleFrameForMonitor(monitor);
+
+    if (!cursor_view->active)
+        cursor_view->layout->on_move(source_ws_id, target_workspace->m_id);
 }
 
 static SDispatchResult change_layer(std::string arg, bool move_window) {
@@ -173,10 +244,10 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     if (cursor_view->layout->layout_name() != "grid")
         return {.success = false, .error = "layers are only supported in grid layout"};
 
-    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-    const int LAYERS = HTConfig::value<Hyprlang::INT>("grid:layers");
-    const int LOOP_LAYERS = HTConfig::value<Hyprlang::INT>("grid:loop_layers");
+    const int ROWS = static_cast<Hyprlang::INT>(HTConfig::value("grid:rows"));
+    const int COLS = static_cast<Hyprlang::INT>(HTConfig::value("grid:cols"));
+    const int LAYERS = static_cast<Hyprlang::INT>(HTConfig::value("grid:layers"));
+    const int LOOP_LAYERS = static_cast<Hyprlang::INT>(HTConfig::value("grid:loop_layers"));
     const int ws_per_layer = std::max(1, ROWS * COLS);
 
     const PHLMONITOR monitor = cursor_view->get_monitor();
@@ -194,14 +265,6 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     const auto active_it = cursor_view->layout->overview_layout.find(source_ws_id);
     if (active_it == cursor_view->layout->overview_layout.end() && !cursor_view->active)
         return {.success = false, .error = "active workspace not in layout"};
-
-    const int original_layer = cursor_view->layout->layer;
-    int resulting_layer = original_layer;
-    if (arg[0] == '+' || arg[0] == '-') {
-        resulting_layer += std::stoi(arg);
-    } else {
-        resulting_layer = std::stoi(arg);
-    }
 
     int source_cell = 0;
     if (active_it != cursor_view->layout->overview_layout.end()) {
@@ -226,18 +289,10 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     const int needed_layers = std::max(1, (int)(monitor_workspaces.size() + ws_per_layer - 1) / ws_per_layer);
     const int effective_layers = std::max(configured_layers, needed_layers);
 
-    // if resulting offset doesn't fit in boundaries
-    if (resulting_layer >= effective_layers || resulting_layer < 0) {
-        // Don't do anything if next is invalid and grid:loop_layers is disabled
-        if (!LOOP_LAYERS)
-            return {};
-        resulting_layer %= effective_layers;
-        if (resulting_layer < 0)
-            resulting_layer += effective_layers;
-    }
-
-    WORKSPACEID target_ws_id = WORKSPACE_INVALID;
-    const int target_slot = resulting_layer * ws_per_layer + source_cell;
+    const int original_layer = cursor_view->layout->layer;
+    int resulting_layer = original_layer;
+    if (!calculate_target_layer(arg, original_layer, effective_layers, LOOP_LAYERS, resulting_layer))
+        return {};
 
     // Preserve the currently visible grid before changing layers, otherwise a
     // rebuild may auto-pack workspaces and make the same cell point elsewhere.
@@ -246,55 +301,21 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
         grid_layout->pin_workspace_to_slot(ws_id, slot);
     }
 
-    set_layer(cursor_view, resulting_layer);
-    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-    target_ws_id = cursor_view->layout->get_ws_id_from_xy(source_cell % COLS, source_cell / COLS);
-
-    PHLWORKSPACE target_workspace = nullptr;
-
-    if (target_ws_id == WORKSPACE_INVALID) {
-        target_workspace = create_workspace_for_monitor(monitor);
-        if (target_workspace == nullptr) {
-            set_layer(cursor_view, original_layer);
-            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-            return {};
-        }
-
-        grid_layout->pin_workspace_to_slot(target_workspace->m_id, target_slot);
-        target_ws_id = target_workspace->m_id;
-        // Newly created workspaces may not be in overview_layout yet, so keep
-        // the pointer instead of looking it up immediately.
-    } else {
-        grid_layout->pin_workspace_to_slot(target_ws_id, target_slot);
-        target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
-    }
-
-    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+    const int target_slot = resulting_layer * ws_per_layer + source_cell;
+    const PHLWORKSPACE target_workspace = find_or_create_target_workspace(
+        cursor_view,
+        monitor,
+        grid_layout,
+        source_cell,
+        target_slot,
+        resulting_layer,
+        original_layer,
+        COLS
+    );
     if (target_workspace == nullptr)
-        target_workspace = cursor_view->layout->get_workspace_from_layout(target_ws_id);
-
-    if (target_workspace == nullptr) {
-        set_layer(cursor_view, original_layer);
-        cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
         return {};
-    }
 
-    if (move_window) {
-        const PHLWINDOW hovered_window = ht_manager->get_window_from_cursor();
-        if (hovered_window != nullptr)
-            g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, target_workspace);
-    }
-
-    monitor->changeWorkspace(target_workspace);
-    cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-    g_pHyprRenderer->damageMonitor(monitor);
-    g_pCompositor->scheduleFrameForMonitor(monitor);
-
-    if (!cursor_view->active) {
-        cursor_view->layout->on_move(source_ws_id, target_ws_id);
-        return {};
-    }
-
+    apply_layer_change(cursor_view, monitor, source_ws_id, target_workspace, move_window);
     return {};
 }
 
@@ -381,8 +402,8 @@ static void on_mouse_button(IPointer::SButtonEvent e, Event::SCallbackInfo& info
 
     const bool pressed = e.state == WL_POINTER_BUTTON_STATE_PRESSED;
 
-    const unsigned int drag_button = HTConfig::value<Hyprlang::INT>("drag_button");
-    const unsigned int select_button = HTConfig::value<Hyprlang::INT>("select_button");
+    const unsigned int drag_button = static_cast<Hyprlang::INT>(HTConfig::value("drag_button"));
+    const unsigned int select_button = static_cast<Hyprlang::INT>(HTConfig::value("select_button"));
 
     if (pressed && e.button == drag_button) {
         info.cancelled = ht_manager->start_window_drag();
@@ -430,7 +451,7 @@ static void cancel_event(Event::SCallbackInfo& info) {
 }
 
 static void notify_config_changes() {
-    const int ROWS = HTConfig::value<Hyprlang::INT>("rows");
+    const int ROWS = static_cast<Hyprlang::INT>(HTConfig::value("rows"));
     if (ROWS != -1) {
         HyprlandAPI::addNotification(
             PHANDLE,
@@ -440,7 +461,7 @@ static void notify_config_changes() {
         );
     }
 
-    CVarList exit_behavior {HTConfig::value<Hyprlang::STRING>("exit_behavior"), 0, 's', true};
+    CVarList exit_behavior {HTConfig::value_string("exit_behavior"), 0, 's', true};
     if (exit_behavior.size() != 0) {
         HyprlandAPI::addNotification(
             PHANDLE,
@@ -504,8 +525,8 @@ static void on_config_reloaded() {
     for (PHTVIEW& view : ht_manager->views) {
         if (view == nullptr)
             continue;
-        const Hyprlang::STRING new_layout = HTConfig::value<Hyprlang::STRING>("layout");
-        if (HTConfig::value<Hyprlang::INT>("close_overview_on_reload")
+        const Hyprlang::STRING new_layout = HTConfig::value_string("layout");
+        if (static_cast<Hyprlang::INT>(HTConfig::value("close_overview_on_reload"))
             || view->layout->layout_name() != new_layout) {
             Log::logger->log(LOG, "[Hyprtasking] Closing overview on config reload");
             view->hide(false);
@@ -537,10 +558,6 @@ static void init_functions() {
     Log::logger->log(LOG, "[Hyprtasking] Attempting hook {}", FNS2[0].signature);
     success = should_render_window_hook->hook() && success;
 
-    // Right now (in v0.54.0) there are several "renderWindow" functions
-    // This is needed so it won't break on update that adds/removes a
-    // function with this name
-    // This, however, requires checking for signautre changes
     static auto FNS3 = HyprlandAPI::findFunctionsByName(
         PHANDLE,
         "_ZN13CHyprRenderer12renderWindowEN9Hyprutils6Memory14CSha"
@@ -570,12 +587,9 @@ static void register_callbacks() {
     static auto P2 = Event::bus()->m_events.input.mouse.move.listen(on_mouse_move);
     static auto P3 = Event::bus()->m_events.input.mouse.axis.listen(on_mouse_axis);
 
-    // TODO: support touch
     static auto P4 = Event::bus()->m_events.input.touch.down.listen([&] (ITouch::SDownEvent e, Event::SCallbackInfo i) { cancel_event(i); } );
     static auto P5 = Event::bus()->m_events.input.touch.up.listen([&] (ITouch::SUpEvent e, Event::SCallbackInfo i) { cancel_event(i); } );
     static auto P6 = Event::bus()->m_events.input.touch.motion.listen([&] (ITouch::SMotionEvent e, Event::SCallbackInfo i) { cancel_event(i); } );
-    // static auto P7 = Event::bus()->m_events.input.touch.cancel.listen([&] (ITouch::SCancelEvent e, Event::SCallbackInfo i) { cancel_event(i); } );
-
 
     static auto P7 = Event::bus()->m_events.gesture.swipe.begin.listen(on_swipe_begin);
     static auto P8 = Event::bus()->m_events.gesture.swipe.update.listen(on_swipe_update);
@@ -604,7 +618,6 @@ static void add_dispatchers() {
 static void init_config() {
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:layout", Hyprlang::STRING {"grid"});
 
-    // general
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:bg_color", Hyprlang::INT {0x000000FF});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:gap_size", Hyprlang::FLOAT {8.f});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:border_size", Hyprlang::FLOAT {4.f});
@@ -631,7 +644,6 @@ static void init_config() {
         Hyprlang::INT {BTN_RIGHT}
     );
 
-    // swipe
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:gestures:enabled", Hyprlang::INT {1});
     HyprlandAPI::addConfigValue(
         PHANDLE,
@@ -659,7 +671,6 @@ static void init_config() {
         Hyprlang::INT {1}
     );
 
-    // grid specific
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:grid:rows", Hyprlang::INT {3});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:grid:cols", Hyprlang::INT {3});
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:grid:layers", Hyprlang::INT {1});
@@ -671,7 +682,6 @@ static void init_config() {
         Hyprlang::INT {0}
     );
 
-    //linear specifig
     HyprlandAPI::addConfigValue(PHANDLE, "plugin:hyprtasking:linear:blur", Hyprlang::INT {1});
     HyprlandAPI::addConfigValue(
         PHANDLE,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -451,7 +451,7 @@ static void notify_config_changes() {
     }
 }
 
-static void register_monitors() {
+static void register_monitors(bool reset_existing_views) {
     if (ht_manager == nullptr)
         return;
 
@@ -468,7 +468,9 @@ static void register_monitors() {
 
         const PHTVIEW view = ht_manager->get_view_from_monitor(monitor);
         if (view != nullptr) {
-            if (!view->active)
+            if (reset_existing_views)
+                view->reset_for_monitor_change();
+            else if (!view->active)
                 view->layout->init_position();
             continue;
         }
@@ -482,6 +484,14 @@ static void register_monitors() {
             monitor->m_transformedSize.y
         );
     }
+}
+
+static void register_monitors() {
+    register_monitors(false);
+}
+
+static void resync_monitor_layouts() {
+    register_monitors(true);
 }
 
 static void on_config_reloaded() {
@@ -572,7 +582,12 @@ static void register_callbacks() {
     static auto P9 = Event::bus()->m_events.gesture.swipe.end.listen(on_swipe_end);
 
     static auto P10 = Event::bus()->m_events.config.reloaded.listen(on_config_reloaded);
-    static auto P11 = Event::bus()->m_events.monitor.added.listen(register_monitors);
+    static auto P11 = Event::bus()->m_events.monitor.added.listen([] (PHLMONITOR monitor) { resync_monitor_layouts(); });
+    static auto P12 = Event::bus()->m_events.monitor.removed.listen([] (PHLMONITOR monitor) { resync_monitor_layouts(); });
+    static auto P13 = Event::bus()->m_events.monitor.layoutChanged.listen(resync_monitor_layouts);
+    static auto P14 = Event::bus()->m_events.workspace.moveToMonitor.listen(
+        [] (PHLWORKSPACE workspace, PHLMONITOR monitor) { resync_monitor_layouts(); }
+    );
 }
 
 static void add_dispatchers() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -454,6 +454,13 @@ static void notify_config_changes() {
 static void register_monitors() {
     if (ht_manager == nullptr)
         return;
+
+    // Purge views whose monitor no longer exists to prevent unbounded growth
+    // after monitor disconnect / idle / reinitialization.
+    std::erase_if(ht_manager->views, [](const PHTVIEW& view) {
+        return view == nullptr || view->get_monitor() == nullptr;
+    });
+
     for (const PHLMONITOR& monitor : g_pCompositor->m_monitors) {
         // Skip monitors that haven't finished initializing
         if (monitor->m_transformedSize.x < 1 || monitor->m_transformedSize.y < 1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -255,15 +255,14 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
     if (target_ws_id == WORKSPACE_INVALID) {
         // Avoid growing workspace IDs when just hopping between empty cells.
         // If the current workspace is empty, move that workspace to the target.
-        if (!move_window && can_reuse_empty_workspace(active_workspace, monitor)) {
-            target_workspace = active_workspace;
-        } else {
-            target_workspace = create_workspace_for_monitor(monitor);
-            if (target_workspace == nullptr) {
-                set_layer(cursor_view, original_layer);
-                cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
-                return {};
-            }
+        if (!move_window)
+            remember_empty_workspace(active_workspace, monitor);
+
+        target_workspace = create_workspace_for_monitor(monitor);
+        if (target_workspace == nullptr) {
+            set_layer(cursor_view, original_layer);
+            cursor_view->layout->build_overview_layout(HT_VIEW_CLOSED);
+            return {};
         }
 
         grid_layout->pin_workspace_to_slot(target_workspace->m_id, target_slot);
@@ -287,8 +286,10 @@ static SDispatchResult change_layer(std::string arg, bool move_window) {
 
     if (move_window) {
         const PHLWINDOW hovered_window = ht_manager->get_window_from_cursor();
-        if (hovered_window != nullptr)
+        if (hovered_window != nullptr) {
             g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, target_workspace);
+            remember_empty_workspace(active_workspace, monitor);
+        }
     }
 
     monitor->changeWorkspace(target_workspace);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -63,7 +63,7 @@ PHLWINDOW HTManager::get_window_from_cursor(bool return_focused) {
     }
 
     const WORKSPACEID ws_id = cursor_view->layout->get_ws_id_from_global(mouse_coords);
-    const PHLWORKSPACE hovered_workspace = g_pCompositor->getWorkspaceByID(ws_id);
+    const PHLWORKSPACE hovered_workspace = cursor_view->layout->get_workspace_from_layout(ws_id);
     if (hovered_workspace == nullptr)
         return nullptr;
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -1,5 +1,7 @@
 #include "manager.hpp"
 
+#include <algorithm>
+
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/desktop/DesktopTypes.hpp>
@@ -16,14 +18,11 @@ HTManager::HTManager() {
 PHTVIEW HTManager::get_view_from_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
         return nullptr;
-    for (PHTVIEW view : views) {
-        if (view == nullptr)
-            continue;
-        if (view->get_monitor() != monitor)
-            continue;
-        return view;
-    }
-    return nullptr;
+
+    const auto it = std::ranges::find_if(views, [monitor](const PHTVIEW& view) {
+        return view != nullptr && view->get_monitor() == monitor;
+    });
+    return it == views.end() ? nullptr : *it;
 }
 
 PHTVIEW HTManager::get_view_from_cursor() {
@@ -31,14 +30,10 @@ PHTVIEW HTManager::get_view_from_cursor() {
 }
 
 PHTVIEW HTManager::get_view_from_id(VIEWID view_id) {
-    for (PHTVIEW view : views) {
-        if (view == nullptr)
-            continue;
-        if (view->monitor_id != view_id)
-            continue;
-        return view;
-    }
-    return nullptr;
+    const auto it = std::ranges::find_if(views, [view_id](const PHTVIEW& view) {
+        return view != nullptr && view->monitor_id == view_id;
+    });
+    return it == views.end() ? nullptr : *it;
 }
 
 PHLWINDOW HTManager::get_window_from_cursor(bool return_focused) {
@@ -71,7 +66,11 @@ PHLWINDOW HTManager::get_window_from_cursor(bool return_focused) {
         + cursor_monitor->m_position;
 
     const PHLWORKSPACEREF o_workspace = cursor_monitor->m_activeWorkspace;
-    cursor_monitor->changeWorkspace(hovered_workspace, true);
+    const PHLMONITOR ws_monitor = g_pCompositor->getMonitorFromID(hovered_workspace->monitorID());
+    if (ws_monitor != nullptr)
+        ws_monitor->changeWorkspace(hovered_workspace, true);
+    else
+        cursor_monitor->changeWorkspace(hovered_workspace, true);
 
     const PHLWINDOW hovered_window = g_pCompositor->vectorToWindowUnified(
         ws_coords,
@@ -113,13 +112,9 @@ void HTManager::reset() {
 }
 
 bool HTManager::has_active_view() {
-    for (const auto& view : views) {
-        if (view == nullptr)
-            continue;
-        if (view->active)
-            return true;
-    }
-    return false;
+    return std::ranges::any_of(views, [](const PHTVIEW& view) {
+        return view != nullptr && view->active;
+    });
 }
 
 bool HTManager::cursor_view_active() {

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -25,6 +25,7 @@ class HTManager {
 
     bool start_window_drag();
     bool end_window_drag();
+    bool mark_workspace();
     bool exit_to_workspace();
     bool on_mouse_move();
     bool on_mouse_axis(double delta);

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -79,13 +79,16 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
                     const int ws_per_layer = std::max(1, ROWS * COLS);
                     const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
-                    workspace = create_workspace_for_monitor(monitor);
+                    if (can_reuse_empty_workspace(monitor->m_activeWorkspace, monitor))
+                        workspace = monitor->m_activeWorkspace;
+                    else
+                        workspace = create_workspace_for_monitor(monitor);
                     if (workspace != nullptr) {
                         grid_layout->pin_workspace_to_slot(workspace->m_id, target_slot);
                         ws_id = workspace->m_id;
                         Log::logger->log(
                             LOG,
-                            "[Hyprtasking] Created workspace {} at slot ({}, {}) on right-click exit",
+                            "[Hyprtasking] Using workspace {} at slot ({}, {}) on right-click exit",
                             workspace->m_id,
                             cell_x,
                             cell_y
@@ -290,7 +293,11 @@ void HTView::move(std::string arg, bool move_window) {
             if (x >= 0 && x < COLS && y >= 0 && y < ROWS) {
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
-                PHLWORKSPACE new_ws = create_workspace_for_monitor(monitor);
+                PHLWORKSPACE new_ws = nullptr;
+                if (!move_window && can_reuse_empty_workspace(active_workspace, monitor))
+                    new_ws = active_workspace;
+                else
+                    new_ws = create_workspace_for_monitor(monitor);
                 if (new_ws != nullptr) {
                     grid_layout->pin_workspace_to_slot(new_ws->m_id, target_slot);
                     move_id(new_ws->m_id, move_window);

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -79,12 +79,10 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
                     const int ws_per_layer = std::max(1, ROWS * COLS);
                     const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
-                    // Right-clicking an empty cell can reuse the current empty
+                    // Right-clicking an empty cell can reuse the last empty
                     // workspace instead of allocating a fresh max+1 id.
-                    if (can_reuse_empty_workspace(monitor->m_activeWorkspace, monitor))
-                        workspace = monitor->m_activeWorkspace;
-                    else
-                        workspace = create_workspace_for_monitor(monitor);
+                    remember_empty_workspace(monitor->m_activeWorkspace, monitor);
+                    workspace = create_workspace_for_monitor(monitor);
                     if (workspace != nullptr) {
                         grid_layout->pin_workspace_to_slot(workspace->m_id, target_slot);
                         ws_id = workspace->m_id;
@@ -297,11 +295,11 @@ void HTView::move(std::string arg, bool move_window) {
                 const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
                 PHLWORKSPACE new_ws = nullptr;
                 // Moving from an empty workspace to an empty cell should reuse
-                // the current id; moving a window still needs a separate target.
-                if (!move_window && can_reuse_empty_workspace(active_workspace, monitor))
-                    new_ws = active_workspace;
-                else
-                    new_ws = create_workspace_for_monitor(monitor);
+                // the last empty id; moving a window still needs a target, but
+                // the source may become reusable after the window leaves.
+                if (!move_window)
+                    remember_empty_workspace(active_workspace, monitor);
+                new_ws = create_workspace_for_monitor(monitor);
                 if (new_ws != nullptr) {
                     grid_layout->pin_workspace_to_slot(new_ws->m_id, target_slot);
                     move_id(new_ws->m_id, move_window);

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -70,12 +70,13 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
             const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
             const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
             if (grid_layout != nullptr) {
-                const auto [cell_x, cell_y] = grid_layout->get_grid_cell_from_global(mouse_coords);
-                if (cell_x >= 0 && cell_y >= 0) {
+                const auto [cell_x, cell_y, cell_layer] = grid_layout->get_grid_cell_from_global(mouse_coords);
+                if (cell_x >= 0 && cell_y >= 0 && cell_layer >= 0) {
+                    grid_layout->layer = cell_layer;
                     const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
                     const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
                     const int ws_per_layer = std::max(1, ROWS * COLS);
-                    const int target_slot = grid_layout->layer * ws_per_layer + cell_y * COLS + cell_x;
+                    const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
                     WORKSPACEID next_id = 1;
                     for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -61,7 +61,7 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
 
     const bool use_hovered = exit_on_mouse || EXIT_ON_HOVERED;
     const WORKSPACEID ws_id = use_hovered ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
-    PHLWORKSPACE workspace = use_hovered ? layout->get_workspace_from_layout(ws_id)
+    PHLWORKSPACE workspace = use_hovered ? layout->get_or_create_workspace_from_layout(ws_id)
                                          : monitor->m_activeWorkspace;
     if (workspace == nullptr)
         return;
@@ -146,7 +146,7 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
         should_move = false;
 
     layout->build_overview_layout(HT_VIEW_CLOSED);
-    PHLWORKSPACE other_workspace = layout->get_workspace_from_layout(ws_id);
+    PHLWORKSPACE other_workspace = layout->get_or_create_workspace_from_layout(ws_id);
     if (other_workspace == nullptr)
         return;
 

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -45,7 +45,7 @@ void HTView::change_layout(const std::string& layout_name) {
 
 void HTView::do_exit_behavior(bool exit_on_mouse) {
     const PHLMONITOR monitor = get_monitor();
-    if (monitor == nullptr) //???
+    if (monitor == nullptr)
         return;
 
     auto try_get_hover_id = [this, &monitor]() {
@@ -60,9 +60,47 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
     const int EXIT_ON_HOVERED = HTConfig::value<Hyprlang::INT>("exit_on_hovered");
 
     const bool use_hovered = exit_on_mouse || EXIT_ON_HOVERED;
-    const WORKSPACEID ws_id = use_hovered ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
+    WORKSPACEID ws_id = use_hovered ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
     PHLWORKSPACE workspace = use_hovered ? layout->get_workspace_from_layout(ws_id)
                                          : monitor->m_activeWorkspace;
+
+    if (use_hovered && ws_id == WORKSPACE_INVALID && layout->layout_name() == "grid") {
+        const PHLMONITOR cursor_monitor = g_pCompositor->getMonitorFromCursor();
+        if (cursor_monitor == monitor) {
+            const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
+            const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
+            if (grid_layout != nullptr) {
+                const auto [cell_x, cell_y] = grid_layout->get_grid_cell_from_global(mouse_coords);
+                if (cell_x >= 0 && cell_y >= 0) {
+                    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+                    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+                    const int ws_per_layer = std::max(1, ROWS * COLS);
+                    const int target_slot = grid_layout->layer * ws_per_layer + cell_y * COLS + cell_x;
+
+                    WORKSPACEID next_id = 1;
+                    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+                        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
+                            next_id = ws->m_id + 1;
+                        }
+                    }
+
+                    workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+                    if (workspace != nullptr) {
+                        grid_layout->pin_workspace_to_slot(next_id, target_slot);
+                        ws_id = next_id;
+                        Log::logger->log(
+                            LOG,
+                            "[Hyprtasking] Created workspace {} at slot ({}, {}) on right-click exit",
+                            next_id,
+                            cell_x,
+                            cell_y
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     if (workspace == nullptr)
         return;
 
@@ -194,6 +232,40 @@ void HTView::move(std::string arg, bool move_window) {
         return;
     const auto ws_layout = ws_layout_it->second;
     const WORKSPACEID id = layout->get_ws_id_in_direction(ws_layout.x, ws_layout.y, arg);
+
+    if (id == WORKSPACE_INVALID && layout->layout_name() == "grid") {
+        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
+        if (grid_layout != nullptr) {
+            int x = ws_layout.x, y = ws_layout.y;
+            if (arg == "up") {
+                y--;
+            } else if (arg == "down") {
+                y++;
+            } else if (arg == "right") {
+                x++;
+            } else if (arg == "left") {
+                x--;
+            }
+            const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+            const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+            if (x >= 0 && x < COLS && y >= 0 && y < ROWS) {
+                const int ws_per_layer = std::max(1, ROWS * COLS);
+                const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
+                WORKSPACEID next_id = 1;
+                for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+                    if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
+                        next_id = ws->m_id + 1;
+                    }
+                }
+                PHLWORKSPACE new_ws = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+                if (new_ws != nullptr) {
+                    grid_layout->pin_workspace_to_slot(next_id, target_slot);
+                    move_id(next_id, move_window);
+                    return;
+                }
+            }
+        }
+    }
 
     move_id(id, move_window);
 }

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -59,12 +59,10 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
 
     const int EXIT_ON_HOVERED = HTConfig::value<Hyprlang::INT>("exit_on_hovered");
 
-    const WORKSPACEID ws_id =
-        (exit_on_mouse || EXIT_ON_HOVERED) ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
-    PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(ws_id);
-
-    if (workspace == nullptr && ws_id != WORKSPACE_INVALID)
-        workspace = g_pCompositor->createNewWorkspace(ws_id, monitor->m_id);
+    const bool use_hovered = exit_on_mouse || EXIT_ON_HOVERED;
+    const WORKSPACEID ws_id = use_hovered ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
+    PHLWORKSPACE workspace = use_hovered ? layout->get_workspace_from_layout(ws_id)
+                                         : monitor->m_activeWorkspace;
     if (workspace == nullptr)
         return;
 
@@ -147,9 +145,8 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
     if (hovered_window == nullptr && move_window)
         should_move = false;
 
-    PHLWORKSPACE other_workspace = g_pCompositor->getWorkspaceByID(ws_id);
-    if (other_workspace == nullptr && ws_id != WORKSPACE_INVALID)
-        other_workspace = g_pCompositor->createNewWorkspace(ws_id, monitor->m_id);
+    layout->build_overview_layout(HT_VIEW_CLOSED);
+    PHLWORKSPACE other_workspace = layout->get_workspace_from_layout(ws_id);
     if (other_workspace == nullptr)
         return;
 
@@ -185,11 +182,17 @@ void HTView::move(std::string arg, bool move_window) {
     if (hovered_window == nullptr && move_window)
         return;
 
+    if (!active && !navigating)
+        layout->init_position();
+
     // if moving a window, the up/down/left/right should be relative to the window (and cursor) and not necessarily the active workspace
     const WORKSPACEID source_ws_id =
         move_window ? hovered_window->workspaceID() : active_workspace->m_id;
     layout->build_overview_layout(HT_VIEW_CLOSED);
-    const auto ws_layout = layout->overview_layout[source_ws_id];
+    const auto ws_layout_it = layout->overview_layout.find(source_ws_id);
+    if (ws_layout_it == layout->overview_layout.end())
+        return;
+    const auto ws_layout = ws_layout_it->second;
     const WORKSPACEID id = layout->get_ws_id_in_direction(ws_layout.x, ws_layout.y, arg);
 
     move_id(id, move_window);

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -15,6 +15,7 @@
 #include "layout/grid.hpp"
 #include "layout/linear.hpp"
 #include "src/desktop/state/FocusState.hpp"
+#include "workspace.hpp"
 
 HTView::HTView(MONITORID in_monitor_id) {
     monitor_id = in_monitor_id;
@@ -78,21 +79,14 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
                     const int ws_per_layer = std::max(1, ROWS * COLS);
                     const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
-                    WORKSPACEID next_id = 1;
-                    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-                        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
-                            next_id = ws->m_id + 1;
-                        }
-                    }
-
-                    workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+                    workspace = create_workspace_for_monitor(monitor);
                     if (workspace != nullptr) {
-                        grid_layout->pin_workspace_to_slot(next_id, target_slot);
-                        ws_id = next_id;
+                        grid_layout->pin_workspace_to_slot(workspace->m_id, target_slot);
+                        ws_id = workspace->m_id;
                         Log::logger->log(
                             LOG,
                             "[Hyprtasking] Created workspace {} at slot ({}, {}) on right-click exit",
-                            next_id,
+                            workspace->m_id,
                             cell_x,
                             cell_y
                         );
@@ -296,16 +290,10 @@ void HTView::move(std::string arg, bool move_window) {
             if (x >= 0 && x < COLS && y >= 0 && y < ROWS) {
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
-                WORKSPACEID next_id = 1;
-                for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-                    if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id) {
-                        next_id = ws->m_id + 1;
-                    }
-                }
-                PHLWORKSPACE new_ws = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+                PHLWORKSPACE new_ws = create_workspace_for_monitor(monitor);
                 if (new_ws != nullptr) {
-                    grid_layout->pin_workspace_to_slot(next_id, target_slot);
-                    move_id(next_id, move_window);
+                    grid_layout->pin_workspace_to_slot(new_ws->m_id, target_slot);
+                    move_id(new_ws->m_id, move_window);
                     return;
                 }
             }

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -17,13 +17,50 @@
 #include "src/desktop/state/FocusState.hpp"
 #include "workspace.hpp"
 
+namespace {
+void exit_to_grid_cell(
+    SP<HTLayoutGrid> grid,
+    PHLMONITOR monitor,
+    Vector2D mouse_coords,
+    WORKSPACEID& ws_id,
+    PHLWORKSPACE& workspace
+) {
+    if (grid == nullptr || monitor == nullptr)
+        return;
+
+    const auto [cell_x, cell_y, cell_layer] = grid->get_grid_cell_from_global(mouse_coords);
+    if (cell_x < 0 || cell_y < 0 || cell_layer < 0)
+        return;
+
+    grid->layer = cell_layer;
+    const int ROWS = static_cast<Hyprlang::INT>(HTConfig::value("grid:rows"));
+    const int COLS = static_cast<Hyprlang::INT>(HTConfig::value("grid:cols"));
+    const int ws_per_layer = std::max(1, ROWS * COLS);
+    const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
+
+    workspace = create_workspace_for_monitor(monitor);
+    if (workspace == nullptr)
+        return;
+
+    grid->pin_workspace_to_slot(workspace->m_id, target_slot);
+    ws_id = workspace->m_id;
+    Log::logger->log(
+        LOG,
+        "[Hyprtasking] Using workspace {} at slot ({}, {}) on right-click exit",
+        workspace->m_id,
+        cell_x,
+        cell_y
+    );
+}
+}
+
 HTView::HTView(MONITORID in_monitor_id) {
     monitor_id = in_monitor_id;
     active = false;
     closing = false;
     navigating = false;
 
-    change_layout(HTConfig::value<Hyprlang::STRING>("layout"));
+    change_layout(HTConfig::value_string("layout"));
 }
 
 void HTView::change_layout(const std::string& layout_name) {
@@ -58,50 +95,33 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
         return layout->get_ws_id_from_global(mouse_coords);
     };
 
-    const int EXIT_ON_HOVERED = HTConfig::value<Hyprlang::INT>("exit_on_hovered");
+    const int EXIT_ON_HOVERED = static_cast<Hyprlang::INT>(HTConfig::value("exit_on_hovered"));
 
     const bool use_hovered = exit_on_mouse || EXIT_ON_HOVERED;
     WORKSPACEID ws_id = use_hovered ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
     PHLWORKSPACE workspace = use_hovered ? layout->get_workspace_from_layout(ws_id)
-                                         : monitor->m_activeWorkspace;
+                                          : monitor->m_activeWorkspace;
 
-    if (use_hovered && ws_id == WORKSPACE_INVALID && layout->layout_name() == "grid") {
+    if (use_hovered && ws_id == WORKSPACE_INVALID) {
         const PHLMONITOR cursor_monitor = g_pCompositor->getMonitorFromCursor();
-        if (cursor_monitor == monitor) {
-            const Vector2D mouse_coords = g_pInputManager->getMouseCoordsInternal();
-            const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
-            if (grid_layout != nullptr) {
-                const auto [cell_x, cell_y, cell_layer] = grid_layout->get_grid_cell_from_global(mouse_coords);
-                if (cell_x >= 0 && cell_y >= 0 && cell_layer >= 0) {
-                    grid_layout->layer = cell_layer;
-                    const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-                    const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-                    const int ws_per_layer = std::max(1, ROWS * COLS);
-                    const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
-
-                    // Keep workspace creation lazy: only create a real Hyprland
-                    // workspace when the user actually exits to this empty cell.
-                    workspace = create_workspace_for_monitor(monitor);
-                    if (workspace != nullptr) {
-                        grid_layout->pin_workspace_to_slot(workspace->m_id, target_slot);
-                        ws_id = workspace->m_id;
-                        Log::logger->log(
-                            LOG,
-                            "[Hyprtasking] Using workspace {} at slot ({}, {}) on right-click exit",
-                            workspace->m_id,
-                            cell_x,
-                            cell_y
-                        );
-                    }
-                }
-            }
-        }
+        if (cursor_monitor == monitor)
+            exit_to_grid_cell(
+                Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout),
+                monitor,
+                g_pInputManager->getMouseCoordsInternal(),
+                ws_id,
+                workspace
+            );
     }
 
     if (workspace == nullptr)
         return;
 
-    monitor->changeWorkspace(workspace);
+    const PHLMONITOR ws_monitor = g_pCompositor->getMonitorFromID(workspace->monitorID());
+    if (ws_monitor != nullptr)
+        ws_monitor->changeWorkspace(workspace);
+    else
+        monitor->changeWorkspace(workspace);
 }
 
 void HTView::show(bool recalculate) {
@@ -204,9 +224,12 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
         g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, other_workspace);
     }
 
-    Hyprlang::INT warp;
-
-    monitor->changeWorkspace(other_workspace);
+    const PHLMONITOR ws_monitor = g_pCompositor->getMonitorFromID(other_workspace->monitorID());
+    if (ws_monitor != nullptr)
+        ws_monitor->changeWorkspace(other_workspace);
+    else
+        monitor->changeWorkspace(other_workspace);
+    Hyprlang::INT warp = 0;
     if (move_window) {
         Desktop::focusState()->fullWindowFocus(hovered_window, Desktop::FOCUS_REASON_CLICK);
         warp = *CConfigValue<Hyprlang::INT>("plugin:hyprtasking:warp_on_move_window");
@@ -238,6 +261,7 @@ void HTView::move(std::string arg, bool move_window) {
     if (arg != "up" && arg != "down" && arg != "left" && arg != "right")
         return;
 
+    const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
         return;
@@ -251,21 +275,17 @@ void HTView::move(std::string arg, bool move_window) {
     if (!active && !navigating)
         layout->init_position();
 
-    // if moving a window, the up/down/left/right should be relative to the window (and cursor) and not necessarily the active workspace
     const WORKSPACEID source_ws_id =
         move_window ? hovered_window->workspaceID() : active_workspace->m_id;
     layout->build_overview_layout(HT_VIEW_CLOSED);
     const auto ws_layout_it = layout->overview_layout.find(source_ws_id);
     HTLayoutBase::HTWorkspace ws_layout;
     if (ws_layout_it == layout->overview_layout.end()) {
-        // After changing to an empty layer, the active workspace may not be in
-        // overview_layout yet. Keep moving from the same grid cell instead.
-        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
         if (grid_layout == nullptr || !active)
             return;
 
-        const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-        const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+        const int ROWS = static_cast<Hyprlang::INT>(HTConfig::value("grid:rows"));
+        const int COLS = static_cast<Hyprlang::INT>(HTConfig::value("grid:cols"));
         const int cell = grid_layout->last_layer_cell;
         if (cell < 0 || cell >= ROWS * COLS)
             return;
@@ -274,48 +294,39 @@ void HTView::move(std::string arg, bool move_window) {
         ws_layout.y = cell / COLS;
     } else {
         ws_layout = ws_layout_it->second;
-        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
         if (grid_layout != nullptr) {
-            const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+            const int COLS = static_cast<Hyprlang::INT>(HTConfig::value("grid:cols"));
             grid_layout->last_layer_cell = ws_layout.y * COLS + ws_layout.x;
         }
     }
     const WORKSPACEID id = layout->get_ws_id_in_direction(ws_layout.x, ws_layout.y, arg);
 
-    if (id == WORKSPACE_INVALID && layout->layout_name() == "grid") {
-        // Moving inside a sparse layer should still be able to land on an empty
-        // grid cell, including wrapped cells when grid:loop is enabled.
-        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
-        if (grid_layout != nullptr) {
-            int x = ws_layout.x, y = ws_layout.y;
-            const int LOOP = HTConfig::value<Hyprlang::INT>("grid:loop");
-            const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-            const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
-            if (arg == "up") {
-                y--;
-            } else if (arg == "down") {
-                y++;
-            } else if (arg == "right") {
-                x++;
-            } else if (arg == "left") {
-                x--;
-            }
-            if (LOOP) {
-                x = (x + COLS) % COLS;
-                y = (y + ROWS) % ROWS;
-            }
-            if (x >= 0 && x < COLS && y >= 0 && y < ROWS) {
-                const int ws_per_layer = std::max(1, ROWS * COLS);
-                const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
-                PHLWORKSPACE new_ws = nullptr;
-                // Keep sparse layers lazy: empty cells are materialized only
-                // when navigation actually lands there.
-                new_ws = create_workspace_for_monitor(monitor);
-                if (new_ws != nullptr) {
-                    grid_layout->pin_workspace_to_slot(new_ws->m_id, target_slot);
-                    move_id(new_ws->m_id, move_window);
-                    return;
-                }
+    if (id == WORKSPACE_INVALID && grid_layout != nullptr) {
+        int x = ws_layout.x, y = ws_layout.y;
+        const int LOOP = static_cast<Hyprlang::INT>(HTConfig::value("grid:loop"));
+        const int ROWS = static_cast<Hyprlang::INT>(HTConfig::value("grid:rows"));
+        const int COLS = static_cast<Hyprlang::INT>(HTConfig::value("grid:cols"));
+        if (arg == "up") {
+            y--;
+        } else if (arg == "down") {
+            y++;
+        } else if (arg == "right") {
+            x++;
+        } else if (arg == "left") {
+            x--;
+        }
+        if (LOOP) {
+            x = (x + COLS) % COLS;
+            y = (y + ROWS) % ROWS;
+        }
+        if (x >= 0 && x < COLS && y >= 0 && y < ROWS) {
+            const int ws_per_layer = std::max(1, ROWS * COLS);
+            const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
+            PHLWORKSPACE new_ws = create_workspace_for_monitor(monitor);
+            if (new_ws != nullptr) {
+                grid_layout->pin_workspace_to_slot(new_ws->m_id, target_slot);
+                move_id(new_ws->m_id, move_window);
+                return;
             }
         }
     }

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -245,7 +245,10 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
     }
     warp_window(warp, hovered_window);
 
-    if (active) {
+    if (active && !move_window) {
+        hide(true);
+        return;
+    } else if (active) {
         layout->build_overview_layout(HT_VIEW_CLOSED);
         g_pHyprRenderer->damageMonitor(monitor);
         g_pCompositor->scheduleFrameForMonitor(monitor);

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -60,6 +60,9 @@ HTView::HTView(MONITORID in_monitor_id) {
     closing = false;
     navigating = false;
 
+    if (PHLMONITOR monitor = g_pCompositor->getMonitorFromID(monitor_id))
+        monitor_name = monitor->m_name;
+
     change_layout(HTConfig::value_string("layout"));
 }
 

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -79,6 +79,8 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
                     const int ws_per_layer = std::max(1, ROWS * COLS);
                     const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
+                    // Right-clicking an empty cell can reuse the current empty
+                    // workspace instead of allocating a fresh max+1 id.
                     if (can_reuse_empty_workspace(monitor->m_activeWorkspace, monitor))
                         workspace = monitor->m_activeWorkspace;
                     else
@@ -294,6 +296,8 @@ void HTView::move(std::string arg, bool move_window) {
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
                 PHLWORKSPACE new_ws = nullptr;
+                // Moving from an empty workspace to an empty cell should reuse
+                // the current id; moving a window still needs a separate target.
                 if (!move_window && can_reuse_empty_workspace(active_workspace, monitor))
                     new_ws = active_workspace;
                 else

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -204,6 +204,16 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
     }
     warp_window(warp, hovered_window);
 
+    if (active) {
+        Log::logger->log(
+            LOG,
+            "[Hyprtasking] move_id changed active view from workspace {} to {} without navigation animation",
+            active_workspace->m_id,
+            other_workspace->m_id
+        );
+        return;
+    }
+
     navigating = true;
     layout->on_move(active_workspace->m_id, other_workspace->m_id, [this](auto self) {
         navigating = false;
@@ -229,9 +239,28 @@ void HTView::move(std::string arg, bool move_window) {
         move_window ? hovered_window->workspaceID() : active_workspace->m_id;
     layout->build_overview_layout(HT_VIEW_CLOSED);
     const auto ws_layout_it = layout->overview_layout.find(source_ws_id);
-    if (ws_layout_it == layout->overview_layout.end())
-        return;
-    const auto ws_layout = ws_layout_it->second;
+    HTLayoutBase::HTWorkspace ws_layout;
+    if (ws_layout_it == layout->overview_layout.end()) {
+        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
+        if (grid_layout == nullptr || !active)
+            return;
+
+        const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+        const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+        const int cell = grid_layout->last_layer_cell;
+        if (cell < 0 || cell >= ROWS * COLS)
+            return;
+
+        ws_layout.x = cell % COLS;
+        ws_layout.y = cell / COLS;
+    } else {
+        ws_layout = ws_layout_it->second;
+        const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
+        if (grid_layout != nullptr) {
+            const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+            grid_layout->last_layer_cell = ws_layout.y * COLS + ws_layout.x;
+        }
+    }
     const WORKSPACEID id = layout->get_ws_id_in_direction(ws_layout.x, ws_layout.y, arg);
 
     if (id == WORKSPACE_INVALID && layout->layout_name() == "grid") {

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -59,6 +59,7 @@ HTView::HTView(MONITORID in_monitor_id) {
     active = false;
     closing = false;
     navigating = false;
+    pre_overview_workspace = WORKSPACE_INVALID;
 
     if (PHLMONITOR monitor = g_pCompositor->getMonitorFromID(monitor_id))
         monitor_name = monitor->m_name;
@@ -101,9 +102,11 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
     const int EXIT_ON_HOVERED = static_cast<Hyprlang::INT>(HTConfig::value("exit_on_hovered"));
 
     const bool use_hovered = exit_on_mouse || EXIT_ON_HOVERED;
-    WORKSPACEID ws_id = use_hovered ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
-    PHLWORKSPACE workspace = use_hovered ? layout->get_workspace_from_layout(ws_id)
-                                          : monitor->m_activeWorkspace;
+    const PHLWORKSPACE hovered_workspace = use_hovered ? layout->get_workspace_from_layout(try_get_hover_id()) : nullptr;
+
+    WORKSPACEID ws_id = use_hovered && hovered_workspace != nullptr ? hovered_workspace->m_id
+                                                                     : pre_overview_workspace;
+    PHLWORKSPACE workspace = layout->get_workspace_from_layout(ws_id);
 
     if (use_hovered && ws_id == WORKSPACE_INVALID) {
         const PHLMONITOR cursor_monitor = g_pCompositor->getMonitorFromCursor();
@@ -138,6 +141,7 @@ void HTView::show(bool recalculate) {
     active = true;
     closing = false;
     navigating = false;
+    pre_overview_workspace = active_workspace->m_id;
 
     if (recalculate) {
         layout->init_position();

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -60,6 +60,7 @@ HTView::HTView(MONITORID in_monitor_id) {
     closing = false;
     navigating = false;
     pre_overview_workspace = WORKSPACE_INVALID;
+    marked_workspace = WORKSPACE_INVALID;
 
     if (PHLMONITOR monitor = g_pCompositor->getMonitorFromID(monitor_id))
         monitor_name = monitor->m_name;
@@ -101,10 +102,11 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
 
     const int EXIT_ON_HOVERED = static_cast<Hyprlang::INT>(HTConfig::value("exit_on_hovered"));
 
-    const bool use_hovered = exit_on_mouse || EXIT_ON_HOVERED;
+    const bool use_hovered = exit_on_mouse || (EXIT_ON_HOVERED && marked_workspace == WORKSPACE_INVALID);
     const PHLWORKSPACE hovered_workspace = use_hovered ? layout->get_workspace_from_layout(try_get_hover_id()) : nullptr;
 
     WORKSPACEID ws_id = use_hovered && hovered_workspace != nullptr ? hovered_workspace->m_id
+                         : marked_workspace != WORKSPACE_INVALID   ? marked_workspace
                                                                      : pre_overview_workspace;
     PHLWORKSPACE workspace = layout->get_workspace_from_layout(ws_id);
 
@@ -142,6 +144,7 @@ void HTView::show(bool recalculate) {
     closing = false;
     navigating = false;
     pre_overview_workspace = active_workspace->m_id;
+    marked_workspace = active_workspace->m_id;
 
     if (recalculate) {
         layout->init_position();
@@ -167,6 +170,7 @@ void HTView::hide(bool exit_on_mouse) {
     active = true;
     closing = true;
     navigating = false;
+    marked_workspace = WORKSPACE_INVALID;
 
     layout->on_hide([this](auto self) {
         active = false;
@@ -177,6 +181,16 @@ void HTView::hide(bool exit_on_mouse) {
 
     g_pHyprRenderer->damageMonitor(monitor);
     g_pCompositor->scheduleFrameForMonitor(monitor);
+}
+
+void HTView::mark_workspace(WORKSPACEID ws_id) {
+    if (ws_id == WORKSPACE_INVALID)
+        return;
+
+    if (layout->get_workspace_from_layout(ws_id) == nullptr)
+        return;
+
+    marked_workspace = ws_id;
 }
 
 void HTView::reset_for_monitor_change() {
@@ -227,6 +241,8 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
     if (other_workspace == nullptr)
         return;
 
+    mark_workspace(other_workspace->m_id);
+
     if (move_window && should_move) {
         g_pCompositor->moveWindowToWorkspaceSafe(hovered_window, other_workspace);
     }
@@ -245,10 +261,7 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
     }
     warp_window(warp, hovered_window);
 
-    if (active && !move_window) {
-        hide(true);
-        return;
-    } else if (active) {
+    if (active) {
         layout->build_overview_layout(HT_VIEW_CLOSED);
         g_pHyprRenderer->damageMonitor(monitor);
         g_pCompositor->scheduleFrameForMonitor(monitor);

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -61,7 +61,7 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
 
     const bool use_hovered = exit_on_mouse || EXIT_ON_HOVERED;
     const WORKSPACEID ws_id = use_hovered ? try_get_hover_id() : monitor->m_activeWorkspace->m_id;
-    PHLWORKSPACE workspace = use_hovered ? layout->get_or_create_workspace_from_layout(ws_id)
+    PHLWORKSPACE workspace = use_hovered ? layout->get_workspace_from_layout(ws_id)
                                          : monitor->m_activeWorkspace;
     if (workspace == nullptr)
         return;
@@ -146,7 +146,7 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
         should_move = false;
 
     layout->build_overview_layout(HT_VIEW_CLOSED);
-    PHLWORKSPACE other_workspace = layout->get_or_create_workspace_from_layout(ws_id);
+    PHLWORKSPACE other_workspace = layout->get_workspace_from_layout(ws_id);
     if (other_workspace == nullptr)
         return;
 

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -267,6 +267,9 @@ void HTView::move(std::string arg, bool move_window) {
         const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
         if (grid_layout != nullptr) {
             int x = ws_layout.x, y = ws_layout.y;
+            const int LOOP = HTConfig::value<Hyprlang::INT>("grid:loop");
+            const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
+            const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
             if (arg == "up") {
                 y--;
             } else if (arg == "down") {
@@ -276,8 +279,10 @@ void HTView::move(std::string arg, bool move_window) {
             } else if (arg == "left") {
                 x--;
             }
-            const int ROWS = HTConfig::value<Hyprlang::INT>("grid:rows");
-            const int COLS = HTConfig::value<Hyprlang::INT>("grid:cols");
+            if (LOOP) {
+                x = (x + COLS) % COLS;
+                y = (y + ROWS) % ROWS;
+            }
             if (x >= 0 && x < COLS && y >= 0 && y < ROWS) {
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -152,6 +152,21 @@ void HTView::hide(bool exit_on_mouse) {
     g_pCompositor->scheduleFrameForMonitor(monitor);
 }
 
+void HTView::reset_for_monitor_change() {
+    active = false;
+    closing = false;
+    navigating = false;
+
+    const PHLMONITOR monitor = get_monitor();
+    if (monitor == nullptr)
+        return;
+
+    layout->init_position();
+    Cursor::overrideController->unsetOverride(Cursor::CURSOR_OVERRIDE_UNKNOWN);
+    g_pHyprRenderer->damageMonitor(monitor);
+    g_pCompositor->scheduleFrameForMonitor(monitor);
+}
+
 void HTView::warp_window(Hyprlang::INT warp, PHLWINDOW window) {
     // taken from Hyprland:
     // https://github.com/hyprwm/Hyprland/blob/ea42041f936d5810c5cfa45d6bece12dde2fd9b6/src/managers/KeybindManager.cpp#L1319

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -79,9 +79,8 @@ void HTView::do_exit_behavior(bool exit_on_mouse) {
                     const int ws_per_layer = std::max(1, ROWS * COLS);
                     const int target_slot = cell_layer * ws_per_layer + cell_y * COLS + cell_x;
 
-                    // Right-clicking an empty cell can reuse the last empty
-                    // workspace instead of allocating a fresh max+1 id.
-                    remember_empty_workspace(monitor->m_activeWorkspace, monitor);
+                    // Keep workspace creation lazy: only create a real Hyprland
+                    // workspace when the user actually exits to this empty cell.
                     workspace = create_workspace_for_monitor(monitor);
                     if (workspace != nullptr) {
                         grid_layout->pin_workspace_to_slot(workspace->m_id, target_slot);
@@ -294,11 +293,8 @@ void HTView::move(std::string arg, bool move_window) {
                 const int ws_per_layer = std::max(1, ROWS * COLS);
                 const int target_slot = grid_layout->layer * ws_per_layer + y * COLS + x;
                 PHLWORKSPACE new_ws = nullptr;
-                // Moving from an empty workspace to an empty cell should reuse
-                // the last empty id; moving a window still needs a target, but
-                // the source may become reusable after the window leaves.
-                if (!move_window)
-                    remember_empty_workspace(active_workspace, monitor);
+                // Keep sparse layers lazy: empty cells are materialized only
+                // when navigation actually lands there.
                 new_ws = create_workspace_for_monitor(monitor);
                 if (new_ws != nullptr) {
                     grid_layout->pin_workspace_to_slot(new_ws->m_id, target_slot);

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -205,6 +205,9 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
     warp_window(warp, hovered_window);
 
     if (active) {
+        layout->build_overview_layout(HT_VIEW_CLOSED);
+        g_pHyprRenderer->damageMonitor(monitor);
+        g_pCompositor->scheduleFrameForMonitor(monitor);
         Log::logger->log(
             LOG,
             "[Hyprtasking] move_id changed active view from workspace {} to {} without navigation animation",
@@ -221,6 +224,9 @@ void HTView::move_id(WORKSPACEID ws_id, bool move_window) {
 }
 
 void HTView::move(std::string arg, bool move_window) {
+    if (arg != "up" && arg != "down" && arg != "left" && arg != "right")
+        return;
+
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
         return;
@@ -241,6 +247,8 @@ void HTView::move(std::string arg, bool move_window) {
     const auto ws_layout_it = layout->overview_layout.find(source_ws_id);
     HTLayoutBase::HTWorkspace ws_layout;
     if (ws_layout_it == layout->overview_layout.end()) {
+        // After changing to an empty layer, the active workspace may not be in
+        // overview_layout yet. Keep moving from the same grid cell instead.
         const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
         if (grid_layout == nullptr || !active)
             return;
@@ -264,6 +272,8 @@ void HTView::move(std::string arg, bool move_window) {
     const WORKSPACEID id = layout->get_ws_id_in_direction(ws_layout.x, ws_layout.y, arg);
 
     if (id == WORKSPACE_INVALID && layout->layout_name() == "grid") {
+        // Moving inside a sparse layer should still be able to land on an empty
+        // grid cell, including wrapped cells when grid:loop is enabled.
         const SP<HTLayoutGrid> grid_layout = Hyprutils::Memory::dynamicPointerCast<HTLayoutGrid, HTLayoutBase>(layout);
         if (grid_layout != nullptr) {
             int x = ws_layout.x, y = ws_layout.y;

--- a/src/overview.hpp
+++ b/src/overview.hpp
@@ -23,6 +23,7 @@ class HTView {
     void change_layout(const std::string& layout_name);
 
     MONITORID monitor_id;
+    std::string monitor_name;
 
     SP<HTLayoutBase> layout;
 

--- a/src/overview.hpp
+++ b/src/overview.hpp
@@ -33,6 +33,7 @@ class HTView {
 
     void show(bool recalculate = true);
     void hide(bool exit_on_mouse);
+    void reset_for_monitor_change();
 
     void move_id(WORKSPACEID ws_id, bool move_window);
     // arg is up, down, left, right;

--- a/src/overview.hpp
+++ b/src/overview.hpp
@@ -19,6 +19,7 @@ class HTView {
     bool navigating;
 
     WORKSPACEID pre_overview_workspace = WORKSPACE_INVALID;
+    WORKSPACEID marked_workspace = WORKSPACE_INVALID;
 
     HTView(MONITORID in_monitor_id);
 
@@ -30,6 +31,7 @@ class HTView {
     SP<HTLayoutBase> layout;
 
     void do_exit_behavior(bool exit_on_mouse);
+    void mark_workspace(WORKSPACEID ws_id);
     void warp_window(Hyprlang::INT warp, PHLWINDOW window);
 
     PHLMONITOR get_monitor();

--- a/src/overview.hpp
+++ b/src/overview.hpp
@@ -18,6 +18,8 @@ class HTView {
     bool active;
     bool navigating;
 
+    WORKSPACEID pre_overview_workspace = WORKSPACE_INVALID;
+
     HTView(MONITORID in_monitor_id);
 
     void change_layout(const std::string& layout_name);

--- a/src/pass/pass_element.cpp
+++ b/src/pass/pass_element.cpp
@@ -1,11 +1,9 @@
 #include "pass_element.hpp"
 
 HTPassElement::HTPassElement() {
-    ;
 }
 
 void HTPassElement::draw(const CRegion& damage) {
-    ;
 }
 
 bool HTPassElement::needsLiveBlur() {

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -1,6 +1,7 @@
 #include "workspace.hpp"
 
 #include <unordered_map>
+#include <set>
 
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/helpers/Monitor.hpp>
@@ -19,16 +20,37 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
         return nullptr;
 
+    // Collect existing workspace IDs on this monitor to find gaps
+    std::set<WORKSPACEID> monitor_ws_ids;
+    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+        if (ws != nullptr && !ws->inert() && !ws->m_isSpecialWorkspace
+            && ws->monitorID() == monitor->m_id) {
+            monitor_ws_ids.insert(ws->m_id);
+        }
+    }
+
+    // Find lowest available ID >= 1 to avoid monotonically growing IDs
+    WORKSPACEID candidate = 1;
+    for (WORKSPACEID id : monitor_ws_ids) {
+        if (id == candidate)
+            ++candidate;
+        else if (id > candidate)
+            break;
+    }
+
+    // Fallback to counter-based allocation if all low IDs are taken
     WORKSPACEID& next_id = next_workspace_ids[monitor->m_id];
+    if (next_id < candidate)
+        next_id = candidate;
 
     while (true) {
-        ++next_id;
-        if (next_id < 0)
-            next_id = 1;
-
         PHLWORKSPACE existing = g_pCompositor->getWorkspaceByID(next_id);
-        if (existing != nullptr)
+        if (existing != nullptr) {
+            ++next_id;
+            if (next_id < 0)
+                next_id = 1;
             continue;
+        }
 
         PHLWORKSPACE workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
         if (workspace == nullptr)

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -31,6 +31,8 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
         return nullptr;
 
+    // Remember only workspaces created by hyprtasking. Hyprland removes empty
+    // non-persistent workspaces, so this gives empty cells their old ID back.
     static std::unordered_map<MONITORID, std::vector<WORKSPACEID>> monitor_workspace_history;
 
     std::unordered_set<WORKSPACEID> used_ids;
@@ -44,6 +46,8 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
             live_monitor_ids.insert(live_monitor->m_id);
     }
 
+    // Drop history for monitors that no longer exist so hotplugging does not
+    // reserve IDs forever for a stale monitor id.
     for (auto it = monitor_workspace_history.begin(); it != monitor_workspace_history.end(); ) {
         if (!live_monitor_ids.contains(it->first))
             it = monitor_workspace_history.erase(it);
@@ -65,6 +69,8 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
 
     std::vector<WORKSPACEID>& remembered_ids = monitor_workspace_history[monitor->m_id];
 
+    // Do not let one monitor reuse another monitor's remembered empty ID. This
+    // keeps split/ranged monitor setups from stealing each other's slots.
     for (const auto& [monitor_id, ids] : monitor_workspace_history) {
         if (monitor_id == monitor->m_id)
             continue;
@@ -85,6 +91,8 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
         if (workspace == nullptr)
             return nullptr;
 
+        // Workspace rules may redirect an ID to another monitor. In that case
+        // do not pin or remember it for this view.
         if (!is_workspace_on_monitor(workspace, monitor->m_id)) {
             created_wrong_monitor_workspace = true;
             return nullptr;
@@ -122,5 +130,7 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     while (used_ids.contains(next_id) || reserved_ids.contains(next_id))
         ++next_id;
 
+    // Last resort: keep the old max+1 behavior, but still avoid IDs reserved by
+    // another monitor's hyprtasking-created empty workspaces.
     return try_create(next_id);
 }

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -4,12 +4,13 @@
 #include <hyprland/src/helpers/Monitor.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
 
+// Safe only for the workspace we are leaving: it already belongs to this
+// monitor, and with no windows Hyprland would clean it up anyway.
 bool can_reuse_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor) {
     return workspace != nullptr && monitor != nullptr && !workspace->inert()
         && !workspace->m_isSpecialWorkspace && workspace->m_id > 0
         && workspace->monitorID() == monitor->m_id && workspace->getWindows() == 0;
 }
-
 
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
@@ -21,5 +22,6 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
             next_id = ws->m_id + 1;
     }
 
+    // Fallback to the old behavior when the source workspace is not reusable.
     return g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
 }

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -1,8 +1,12 @@
 #include "workspace.hpp"
 
+#include <unordered_map>
+
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/helpers/Monitor.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
+
+static std::unordered_map<MONITORID, WORKSPACEID> reusable_workspace_ids;
 
 // Safe only for the workspace we are leaving: it already belongs to this
 // monitor, and with no windows Hyprland would clean it up anyway.
@@ -12,9 +16,29 @@ bool can_reuse_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor) {
         && workspace->monitorID() == monitor->m_id && workspace->getWindows() == 0;
 }
 
+void remember_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor) {
+    if (can_reuse_empty_workspace(workspace, monitor))
+        reusable_workspace_ids[monitor->m_id] = workspace->m_id;
+}
+
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
         return nullptr;
+
+    const auto reusable_it = reusable_workspace_ids.find(monitor->m_id);
+    if (reusable_it != reusable_workspace_ids.end()) {
+        const WORKSPACEID reusable_id = reusable_it->second;
+        reusable_workspace_ids.erase(reusable_it);
+
+        // If the empty workspace still exists, use it directly. Otherwise ask
+        // Hyprland to recreate the same id instead of going to max+1.
+        PHLWORKSPACE reusable_workspace = g_pCompositor->getWorkspaceByID(reusable_id);
+        if (can_reuse_empty_workspace(reusable_workspace, monitor))
+            return reusable_workspace;
+
+        if (reusable_workspace == nullptr && reusable_id > 0)
+            return g_pCompositor->createNewWorkspace(reusable_id, monitor->m_id, "", false);
+    }
 
     WORKSPACEID next_id = 1;
     for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -1,6 +1,5 @@
 #include "workspace.hpp"
 
-#include <limits>
 #include <unordered_map>
 
 #include <hyprland/src/Compositor.hpp>
@@ -16,39 +15,16 @@ static bool is_workspace_on_monitor(PHLWORKSPACE workspace, PHLMONITOR monitor) 
         && !workspace->m_isSpecialWorkspace && workspace->monitorID() == monitor->m_id;
 }
 
-static WORKSPACEID highest_workspace_id_on_monitor(PHLMONITOR monitor) {
-    WORKSPACEID highest_id = 0;
-    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-        if (is_workspace_on_monitor(ws, monitor) && ws->m_id > highest_id)
-            highest_id = ws->m_id;
-    }
-    return highest_id;
-}
-
-static WORKSPACEID highest_workspace_id() {
-    WORKSPACEID highest_id = 0;
-    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id > highest_id)
-            highest_id = ws->m_id;
-    }
-    return highest_id;
-}
-
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
         return nullptr;
 
     WORKSPACEID& next_id = next_workspace_ids[monitor->m_id];
-    if (next_id <= 0)
-        // Start after the monitor's own range instead of from the global max;
-        // this keeps split-monitor/ranged setups from jumping unnecessarily.
-        next_id = highest_workspace_id_on_monitor(monitor);
 
-    constexpr int MAX_ATTEMPTS = 10000;
-    for (int attempts = 0; attempts < MAX_ATTEMPTS; ++attempts) {
-        if (next_id >= std::numeric_limits<WORKSPACEID>::max())
-            next_id = 0;
+    while (true) {
         ++next_id;
+        if (next_id < 0)
+            next_id = 1;
 
         PHLWORKSPACE existing = g_pCompositor->getWorkspaceByID(next_id);
         if (existing != nullptr)
@@ -56,7 +32,7 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
 
         PHLWORKSPACE workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
         if (workspace == nullptr)
-            continue;
+            return nullptr;
 
         // Workspace rules may redirect an id to another monitor. Do not keep
         // probing after that, or we could create a chain of wrong workspaces.
@@ -65,17 +41,4 @@ PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
 
         return nullptr;
     }
-
-    // Extremely dense layouts can fill the bounded search window. Fall back to
-    // the old global max+1 behavior rather than failing forever.
-    next_id = highest_workspace_id();
-    if (next_id >= std::numeric_limits<WORKSPACEID>::max())
-        return nullptr;
-    ++next_id;
-
-    PHLWORKSPACE workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
-    if (is_workspace_on_monitor(workspace, monitor))
-        return workspace;
-
-    return nullptr;
 }

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -1,51 +1,81 @@
 #include "workspace.hpp"
 
+#include <limits>
 #include <unordered_map>
 
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/helpers/Monitor.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
 
-static std::unordered_map<MONITORID, WORKSPACEID> reusable_workspace_ids;
+static std::unordered_map<MONITORID, WORKSPACEID> next_workspace_ids;
 
-// Safe only for the workspace we are leaving: it already belongs to this
-// monitor, and with no windows Hyprland would clean it up anyway.
-bool can_reuse_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor) {
+// Keep allocation local to the requested monitor. Workspace rules may move a
+// newly created id elsewhere, so every candidate is checked before returning.
+static bool is_workspace_on_monitor(PHLWORKSPACE workspace, PHLMONITOR monitor) {
     return workspace != nullptr && monitor != nullptr && !workspace->inert()
-        && !workspace->m_isSpecialWorkspace && workspace->m_id > 0
-        && workspace->monitorID() == monitor->m_id && workspace->getWindows() == 0;
+        && !workspace->m_isSpecialWorkspace && workspace->monitorID() == monitor->m_id;
 }
 
-void remember_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor) {
-    if (can_reuse_empty_workspace(workspace, monitor))
-        reusable_workspace_ids[monitor->m_id] = workspace->m_id;
+static WORKSPACEID highest_workspace_id_on_monitor(PHLMONITOR monitor) {
+    WORKSPACEID highest_id = 0;
+    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+        if (is_workspace_on_monitor(ws, monitor) && ws->m_id > highest_id)
+            highest_id = ws->m_id;
+    }
+    return highest_id;
+}
+
+static WORKSPACEID highest_workspace_id() {
+    WORKSPACEID highest_id = 0;
+    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id > highest_id)
+            highest_id = ws->m_id;
+    }
+    return highest_id;
 }
 
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
         return nullptr;
 
-    const auto reusable_it = reusable_workspace_ids.find(monitor->m_id);
-    if (reusable_it != reusable_workspace_ids.end()) {
-        const WORKSPACEID reusable_id = reusable_it->second;
-        reusable_workspace_ids.erase(reusable_it);
+    WORKSPACEID& next_id = next_workspace_ids[monitor->m_id];
+    if (next_id <= 0)
+        // Start after the monitor's own range instead of from the global max;
+        // this keeps split-monitor/ranged setups from jumping unnecessarily.
+        next_id = highest_workspace_id_on_monitor(monitor);
 
-        // If the empty workspace still exists, use it directly. Otherwise ask
-        // Hyprland to recreate the same id instead of going to max+1.
-        PHLWORKSPACE reusable_workspace = g_pCompositor->getWorkspaceByID(reusable_id);
-        if (can_reuse_empty_workspace(reusable_workspace, monitor))
-            return reusable_workspace;
+    constexpr int MAX_ATTEMPTS = 10000;
+    for (int attempts = 0; attempts < MAX_ATTEMPTS; ++attempts) {
+        if (next_id >= std::numeric_limits<WORKSPACEID>::max())
+            next_id = 0;
+        ++next_id;
 
-        if (reusable_workspace == nullptr && reusable_id > 0)
-            return g_pCompositor->createNewWorkspace(reusable_id, monitor->m_id, "", false);
+        PHLWORKSPACE existing = g_pCompositor->getWorkspaceByID(next_id);
+        if (existing != nullptr)
+            continue;
+
+        PHLWORKSPACE workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+        if (workspace == nullptr)
+            continue;
+
+        // Workspace rules may redirect an id to another monitor. Do not keep
+        // probing after that, or we could create a chain of wrong workspaces.
+        if (is_workspace_on_monitor(workspace, monitor))
+            return workspace;
+
+        return nullptr;
     }
 
-    WORKSPACEID next_id = 1;
-    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id)
-            next_id = ws->m_id + 1;
-    }
+    // Extremely dense layouts can fill the bounded search window. Fall back to
+    // the old global max+1 behavior rather than failing forever.
+    next_id = highest_workspace_id();
+    if (next_id >= std::numeric_limits<WORKSPACEID>::max())
+        return nullptr;
+    ++next_id;
 
-    // Fallback to the old behavior when the source workspace is not reusable.
-    return g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+    PHLWORKSPACE workspace = g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
+    if (is_workspace_on_monitor(workspace, monitor))
+        return workspace;
+
+    return nullptr;
 }

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -1,136 +1,25 @@
 #include "workspace.hpp"
 
-#include <algorithm>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/helpers/Monitor.hpp>
+#include <hyprland/src/desktop/Workspace.hpp>
 
-static void remember_workspace_id(std::vector<WORKSPACEID>& ids, WORKSPACEID id) {
-    if (id <= 0 || std::ranges::find(ids, id) != ids.end())
-        return;
-    ids.push_back(id);
-    std::ranges::sort(ids);
+bool can_reuse_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor) {
+    return workspace != nullptr && monitor != nullptr && !workspace->inert()
+        && !workspace->m_isSpecialWorkspace && workspace->m_id > 0
+        && workspace->monitorID() == monitor->m_id && workspace->getWindows() == 0;
 }
 
-static PHLWORKSPACE create_workspace_with_id(PHLMONITOR monitor, WORKSPACEID id) {
-    if (id <= 0)
-        return nullptr;
-
-    return g_pCompositor->createNewWorkspace(id, monitor->m_id, "", false);
-}
-
-static bool is_workspace_on_monitor(PHLWORKSPACE workspace, MONITORID monitor_id) {
-    return workspace != nullptr && !workspace->inert() && !workspace->m_isSpecialWorkspace
-        && workspace->monitorID() == monitor_id;
-}
 
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
     if (monitor == nullptr)
         return nullptr;
 
-    // Remember only workspaces created by hyprtasking. Hyprland removes empty
-    // non-persistent workspaces, so this gives empty cells their old ID back.
-    static std::unordered_map<MONITORID, std::vector<WORKSPACEID>> monitor_workspace_history;
-
-    std::unordered_set<WORKSPACEID> used_ids;
-    std::unordered_set<WORKSPACEID> reserved_ids;
-    std::unordered_set<MONITORID> live_monitor_ids;
-    std::vector<WORKSPACEID> monitor_ids;
     WORKSPACEID next_id = 1;
-
-    for (const PHLMONITOR& live_monitor : g_pCompositor->m_monitors) {
-        if (live_monitor != nullptr)
-            live_monitor_ids.insert(live_monitor->m_id);
-    }
-
-    // Drop history for monitors that no longer exist so hotplugging does not
-    // reserve IDs forever for a stale monitor id.
-    for (auto it = monitor_workspace_history.begin(); it != monitor_workspace_history.end(); ) {
-        if (!live_monitor_ids.contains(it->first))
-            it = monitor_workspace_history.erase(it);
-        else
-            ++it;
-    }
-
     for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
-        if (ws == nullptr || ws->m_isSpecialWorkspace)
-            continue;
-
-        used_ids.insert(ws->m_id);
-        if (ws->m_id >= next_id)
+        if (ws != nullptr && !ws->m_isSpecialWorkspace && ws->m_id >= next_id)
             next_id = ws->m_id + 1;
-
-        if (is_workspace_on_monitor(ws, monitor->m_id) && ws->m_id > 0)
-            monitor_ids.push_back(ws->m_id);
     }
 
-    std::vector<WORKSPACEID>& remembered_ids = monitor_workspace_history[monitor->m_id];
-
-    // Do not let one monitor reuse another monitor's remembered empty ID. This
-    // keeps split/ranged monitor setups from stealing each other's slots.
-    for (const auto& [monitor_id, ids] : monitor_workspace_history) {
-        if (monitor_id == monitor->m_id)
-            continue;
-
-        for (WORKSPACEID id : ids) {
-            if (id > 0)
-                reserved_ids.insert(id);
-        }
-    }
-
-    bool created_wrong_monitor_workspace = false;
-
-    auto try_create = [&](WORKSPACEID id) -> PHLWORKSPACE {
-        if (created_wrong_monitor_workspace || id <= 0 || used_ids.contains(id) || reserved_ids.contains(id))
-            return nullptr;
-
-        PHLWORKSPACE workspace = create_workspace_with_id(monitor, id);
-        if (workspace == nullptr)
-            return nullptr;
-
-        // Workspace rules may redirect an ID to another monitor. In that case
-        // do not pin or remember it for this view.
-        if (!is_workspace_on_monitor(workspace, monitor->m_id)) {
-            created_wrong_monitor_workspace = true;
-            return nullptr;
-        }
-
-        remember_workspace_id(remembered_ids, workspace->m_id);
-        return workspace;
-    };
-
-    // Prefer IDs hyprtasking already created for this monitor. Empty non-
-    // persistent workspaces can disappear, so this keeps revisiting the same
-    // empty grid slot from steadily increasing workspace IDs.
-    for (WORKSPACEID id : remembered_ids) {
-        if (PHLWORKSPACE workspace = try_create(id); workspace != nullptr)
-            return workspace;
-        if (created_wrong_monitor_workspace)
-            return nullptr;
-    }
-
-    if (!monitor_ids.empty()) {
-        std::ranges::sort(monitor_ids);
-        const WORKSPACEID first_id = monitor_ids.front();
-        const WORKSPACEID last_id = monitor_ids.back();
-
-        // Only fill gaps inside this monitor's existing ID span. Reusing the
-        // global lowest free ID could cross monitor-specific workspace ranges.
-        for (WORKSPACEID id = first_id; id <= last_id; ++id) {
-            if (PHLWORKSPACE workspace = try_create(id); workspace != nullptr)
-                return workspace;
-            if (created_wrong_monitor_workspace)
-                return nullptr;
-        }
-    }
-
-    while (used_ids.contains(next_id) || reserved_ids.contains(next_id))
-        ++next_id;
-
-    // Last resort: keep the old max+1 behavior, but still avoid IDs reserved by
-    // another monitor's hyprtasking-created empty workspaces.
-    return try_create(next_id);
+    return g_pCompositor->createNewWorkspace(next_id, monitor->m_id, "", false);
 }

--- a/src/workspace.cpp
+++ b/src/workspace.cpp
@@ -1,0 +1,126 @@
+#include "workspace.hpp"
+
+#include <algorithm>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <hyprland/src/Compositor.hpp>
+#include <hyprland/src/helpers/Monitor.hpp>
+
+static void remember_workspace_id(std::vector<WORKSPACEID>& ids, WORKSPACEID id) {
+    if (id <= 0 || std::ranges::find(ids, id) != ids.end())
+        return;
+    ids.push_back(id);
+    std::ranges::sort(ids);
+}
+
+static PHLWORKSPACE create_workspace_with_id(PHLMONITOR monitor, WORKSPACEID id) {
+    if (id <= 0)
+        return nullptr;
+
+    return g_pCompositor->createNewWorkspace(id, monitor->m_id, "", false);
+}
+
+static bool is_workspace_on_monitor(PHLWORKSPACE workspace, MONITORID monitor_id) {
+    return workspace != nullptr && !workspace->inert() && !workspace->m_isSpecialWorkspace
+        && workspace->monitorID() == monitor_id;
+}
+
+PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor) {
+    if (monitor == nullptr)
+        return nullptr;
+
+    static std::unordered_map<MONITORID, std::vector<WORKSPACEID>> monitor_workspace_history;
+
+    std::unordered_set<WORKSPACEID> used_ids;
+    std::unordered_set<WORKSPACEID> reserved_ids;
+    std::unordered_set<MONITORID> live_monitor_ids;
+    std::vector<WORKSPACEID> monitor_ids;
+    WORKSPACEID next_id = 1;
+
+    for (const PHLMONITOR& live_monitor : g_pCompositor->m_monitors) {
+        if (live_monitor != nullptr)
+            live_monitor_ids.insert(live_monitor->m_id);
+    }
+
+    for (auto it = monitor_workspace_history.begin(); it != monitor_workspace_history.end(); ) {
+        if (!live_monitor_ids.contains(it->first))
+            it = monitor_workspace_history.erase(it);
+        else
+            ++it;
+    }
+
+    for (PHLWORKSPACE ws : g_pCompositor->getWorkspacesCopy()) {
+        if (ws == nullptr || ws->m_isSpecialWorkspace)
+            continue;
+
+        used_ids.insert(ws->m_id);
+        if (ws->m_id >= next_id)
+            next_id = ws->m_id + 1;
+
+        if (is_workspace_on_monitor(ws, monitor->m_id) && ws->m_id > 0)
+            monitor_ids.push_back(ws->m_id);
+    }
+
+    std::vector<WORKSPACEID>& remembered_ids = monitor_workspace_history[monitor->m_id];
+
+    for (const auto& [monitor_id, ids] : monitor_workspace_history) {
+        if (monitor_id == monitor->m_id)
+            continue;
+
+        for (WORKSPACEID id : ids) {
+            if (id > 0)
+                reserved_ids.insert(id);
+        }
+    }
+
+    bool created_wrong_monitor_workspace = false;
+
+    auto try_create = [&](WORKSPACEID id) -> PHLWORKSPACE {
+        if (created_wrong_monitor_workspace || id <= 0 || used_ids.contains(id) || reserved_ids.contains(id))
+            return nullptr;
+
+        PHLWORKSPACE workspace = create_workspace_with_id(monitor, id);
+        if (workspace == nullptr)
+            return nullptr;
+
+        if (!is_workspace_on_monitor(workspace, monitor->m_id)) {
+            created_wrong_monitor_workspace = true;
+            return nullptr;
+        }
+
+        remember_workspace_id(remembered_ids, workspace->m_id);
+        return workspace;
+    };
+
+    // Prefer IDs hyprtasking already created for this monitor. Empty non-
+    // persistent workspaces can disappear, so this keeps revisiting the same
+    // empty grid slot from steadily increasing workspace IDs.
+    for (WORKSPACEID id : remembered_ids) {
+        if (PHLWORKSPACE workspace = try_create(id); workspace != nullptr)
+            return workspace;
+        if (created_wrong_monitor_workspace)
+            return nullptr;
+    }
+
+    if (!monitor_ids.empty()) {
+        std::ranges::sort(monitor_ids);
+        const WORKSPACEID first_id = monitor_ids.front();
+        const WORKSPACEID last_id = monitor_ids.back();
+
+        // Only fill gaps inside this monitor's existing ID span. Reusing the
+        // global lowest free ID could cross monitor-specific workspace ranges.
+        for (WORKSPACEID id = first_id; id <= last_id; ++id) {
+            if (PHLWORKSPACE workspace = try_create(id); workspace != nullptr)
+                return workspace;
+            if (created_wrong_monitor_workspace)
+                return nullptr;
+        }
+    }
+
+    while (used_ids.contains(next_id) || reserved_ids.contains(next_id))
+        ++next_id;
+
+    return try_create(next_id);
+}

--- a/src/workspace.hpp
+++ b/src/workspace.hpp
@@ -3,5 +3,3 @@
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor);
-bool can_reuse_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor);
-void remember_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor);

--- a/src/workspace.hpp
+++ b/src/workspace.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <hyprland/src/desktop/DesktopTypes.hpp>
+
+PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor);

--- a/src/workspace.hpp
+++ b/src/workspace.hpp
@@ -4,3 +4,4 @@
 
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor);
 bool can_reuse_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor);
+void remember_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor);

--- a/src/workspace.hpp
+++ b/src/workspace.hpp
@@ -3,3 +3,4 @@
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 
 PHLWORKSPACE create_workspace_for_monitor(PHLMONITOR monitor);
+bool can_reuse_empty_workspace(PHLWORKSPACE workspace, PHLMONITOR monitor);


### PR DESCRIPTION
Build the tasking overview from Hyprland’s real workspace-to-monitor state instead of synthetic global workspace IDs. This prevents opening, rendering, closing, navigation, and drag-and-drop from moving or reassigning workspaces across monitors while keeping move targets tied to the actual displayed workspace.


Fixes #90
Fixes #96
Fixes #61