### PR TITLE
Fix build on Hyprland 0.55.2 (render pass API change)

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -2,7 +2,7 @@
 name = "hyprtasking"
 authors = ["raybbian"]
 commit_pins = [
-    # ["39d7e209c79d451efab1b21151d5938289da838d", ""], #v0.55.2
+    ["39d7e209c79d451efab1b21151d5938289da838d", ""], #v0.55.2
     # ["a47147bc095e5b3be3eb8bd04f0ac242b968cd4d", ""], #v0.55.1
     # ["af923e30d1d24f1f4a4f5cb8308065173c1d9539", ""], #v0.55.0
     ["521ece463c4a9d3d128670688a34756805a4328f", "630583854a903cf5990505080297933d782c5583"], #v0.54.3

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -84,7 +84,7 @@ const std::string CLEAR_PASS_ELEMENT_NAME = "CClearPassElement";
 void HTLayoutBase::post_render() {
     bool first = true;
     std::erase_if(g_pHyprRenderer->m_renderPass.m_passElements, [&first](const auto& e) {
-        bool res = e.element->passName() == CLEAR_PASS_ELEMENT_NAME && !first;
+        bool res = e->element->passName() == CLEAR_PASS_ELEMENT_NAME && !first;
         first = false;
         return res;
     });


### PR DESCRIPTION
## What

Fixes the plugin failing to build against **Hyprland 0.55.2**.

## Why

In 0.55.2, `CRenderPass::m_passElements` changed type:

\`\`\`cpp
// render/pass/Pass.hpp
std::vector<UP<SPassElementData>> m_passElements;   // was vector<SPassElementData>
\`\`\`

So the \`std::erase_if\` lambda in \`HTLayoutBase::post_render()\` now receives a
\`UP<SPassElementData>\` (unique-pointer) rather than the struct by value, and the
existing \`e.element\` no longer compiles:

\`\`\`
src/layout/layout_base.cpp:87:22: error: 'const class Hyprutils::Memory::CUniquePointer<Render::CRenderPass::SPassElementData>' has no member named 'element'
\`\`\`

## Change

- \`e.element->passName()\` → \`e->element->passName()\` (dereference the UP first).
- Uncomment the \`v0.55.2\` commit pin in \`hyprpm.toml\` so hyprpm accepts the plugin on 0.55.2.

## Testing

Builds clean and loads live on Hyprland 0.55.2 (commit \`39d7e209\`); \`hyprtasking:toggle\` works.

