### PR TITLE
Add keyboard workspace jump labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ https://github.com/user-attachments/assets/8d6cdfd2-2b17-4240-a117-1dbd2231ed4e
 - [x] Mouse controls
     - [x] Exit into workspace (hover, click)
     - [x] Drag and drop windows
-- [ ] Keyboard controls
+- [x] Keyboard controls
     - [x] Switch workspaces with direction
-    - [ ] Switch workspaces with absolute number
+    - [x] Switch workspaces with jump labels
 - [x] Multi-monitor support (tested)
 - [x] Monitor scaling support (tested)
 - [x] Animation support
@@ -108,6 +108,8 @@ hyprctl plugin load "$(realpath libhyprtasking.so)"
 - Workspace Transitioning:
     - Open the overlay, then use **right click** to switch to a workspace
     - Use the directional dispatchers `hyprtasking:move` to switch to a workspace
+    - With `jump.enabled` enabled, press the label shown over a workspace to jump to it
+      (`1`-`9`, `0`, then `a`-`z`)
 - Window management:
     - **Left click** to drag and drop windows around
 
@@ -154,6 +156,13 @@ hl.config({
       -- for other mouse buttons see <linux/input-event-codes.h>
       drag_button = 0x110,   -- left mouse button
       select_button = 0x111, -- right mouse button
+
+      jump = {
+        enabled = false,
+        label_color = 0xffffffff,
+        label_background = 0x000000cc,
+        label_size = 32,
+      },
 
       gestures = {
         enabled = true,
@@ -223,6 +232,13 @@ plugin {
         drag_button = 0x110 # left mouse button
         select_button = 0x111 # right mouse button
         # for other mouse buttons see <linux/input-event-codes.h>
+
+        jump {
+            enabled = false
+            label_color = 0xffffffff
+            label_background = 0x000000cc
+            label_size = 32
+        }
 
         gestures {
             enabled = true

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -1,5 +1,6 @@
 #include <linux/input-event-codes.h>
 
+#include <array>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/macros.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
@@ -189,6 +190,76 @@ bool HTManager::exit_to_workspace() {
         if (view == nullptr)
             continue;
         view->hide(true);
+    }
+    return true;
+}
+
+bool HTManager::on_key(IKeyboard::SKeyEvent event) {
+    if (event.state == WL_KEYBOARD_KEY_STATE_RELEASED && jump_pressed_keys.erase(event.keycode) > 0)
+        return true;
+
+    if (!HTConfig::value<Config::INTEGER>("jump:enabled"))
+        return false;
+
+    const PHTVIEW cursor_view = get_view_from_cursor();
+    if (cursor_view == nullptr || !cursor_view->active)
+        return false;
+
+    std::optional<size_t> index;
+    bool resolved_keyboard = false;
+    for (const auto& keyboard : g_pInputManager->m_keyboards) {
+        if (keyboard == nullptr || keyboard->m_xkbState == nullptr
+            || !keyboard->getPressed(event.keycode))
+            continue;
+
+        resolved_keyboard = true;
+        const xkb_keysym_t keysym =
+            xkb_keysym_to_lower(xkb_state_key_get_one_sym(keyboard->m_xkbState, event.keycode + 8));
+        if (keysym >= XKB_KEY_1 && keysym <= XKB_KEY_9)
+            index = keysym - XKB_KEY_1;
+        else if (keysym == XKB_KEY_0)
+            index = 9;
+        else if (keysym >= XKB_KEY_a && keysym <= XKB_KEY_z)
+            index = 10 + keysym - XKB_KEY_a;
+        break;
+    }
+
+    // Physical-key fallback for unusual keyboard implementations without XKB state.
+    if (!resolved_keyboard) {
+        static constexpr std::array<unsigned int, 36> KEYCODES = {
+            KEY_1, KEY_2, KEY_3, KEY_4, KEY_5, KEY_6, KEY_7, KEY_8, KEY_9, KEY_0, KEY_A, KEY_B,
+            KEY_C, KEY_D, KEY_E, KEY_F, KEY_G, KEY_H, KEY_I, KEY_J, KEY_K, KEY_L, KEY_M, KEY_N,
+            KEY_O, KEY_P, KEY_Q, KEY_R, KEY_S, KEY_T, KEY_U, KEY_V, KEY_W, KEY_X, KEY_Y, KEY_Z,
+        };
+        for (size_t i = 0; i < KEYCODES.size(); i++) {
+            if (KEYCODES[i] == event.keycode) {
+                index = i;
+                break;
+            }
+        }
+    }
+
+    if (!index.has_value())
+        return false;
+
+    const auto target = cursor_view->layout->jump_target(*index);
+    if (!target.has_value())
+        return false;
+
+    // Keep consuming the matching release even if the close animation has finished by then.
+    jump_pressed_keys.insert(event.keycode);
+
+    // Act only on the initial press.
+    if (event.state != WL_KEYBOARD_KEY_STATE_PRESSED || cursor_view->closing)
+        return true;
+
+    for (const PHTVIEW& view : views) {
+        if (view == nullptr || !view->active)
+            continue;
+        if (view == cursor_view)
+            view->hide(false, *target);
+        else
+            view->hide(false);
     }
     return true;
 }

--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -1,5 +1,8 @@
+#include <algorithm>
 #include <any>
+#include <cmath>
 #include <sstream>
+#include <string_view>
 
 #define private public
 #include <hyprland/src/config/ConfigManager.hpp>
@@ -7,8 +10,11 @@
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/render/Renderer.hpp>
 #include <hyprland/src/render/pass/ClearPassElement.hpp>
+#include <hyprland/src/render/pass/RectPassElement.hpp>
+#include <hyprland/src/render/pass/TexPassElement.hpp>
 #undef private
 
+#include "../config.hpp"
 #include "../globals.hpp"
 #include "../pass/pass_element.hpp"
 #include "../types.hpp"
@@ -79,6 +85,102 @@ void HTLayoutBase::render() {
     g_pHyprRenderer->m_renderPass.add(makeUnique<CClearPassElement>(data));
 }
 
+std::vector<WORKSPACEID> HTLayoutBase::jump_targets() const {
+    std::vector<std::pair<WORKSPACEID, HTWorkspace>> ordered;
+    ordered.reserve(overview_layout.size());
+    for (const auto& entry : overview_layout)
+        ordered.push_back(entry);
+
+    std::sort(ordered.begin(), ordered.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.second.y != rhs.second.y)
+            return lhs.second.y < rhs.second.y;
+        if (lhs.second.x != rhs.second.x)
+            return lhs.second.x < rhs.second.x;
+        return lhs.first < rhs.first;
+    });
+
+    std::vector<WORKSPACEID> result;
+    result.reserve(ordered.size());
+    for (const auto& entry : ordered)
+        result.push_back(entry.first);
+    return result;
+}
+
+std::optional<WORKSPACEID> HTLayoutBase::jump_target(size_t index) const {
+    const auto targets = jump_targets();
+    if (index >= targets.size())
+        return std::nullopt;
+    return targets[index];
+}
+
+void HTLayoutBase::render_jump_labels() {
+    if (!HTConfig::value<Config::INTEGER>("jump:enabled"))
+        return;
+
+    const PHTVIEW view = ht_manager->get_view_from_id(view_id);
+    const PHLMONITOR monitor = view == nullptr ? nullptr : view->get_monitor();
+    if (view == nullptr || monitor == nullptr || !view->active || view->closing)
+        return;
+
+    static constexpr std::string_view LABELS = "1234567890abcdefghijklmnopqrstuvwxyz";
+    const auto targets = jump_targets();
+    const size_t count = std::min(targets.size(), LABELS.size());
+
+    const int font_size = std::max(
+        1,
+        static_cast<int>(HTConfig::value<Config::INTEGER>("jump:label_size") * monitor->m_scale)
+    );
+    const float padding = std::max(4.f, font_size * 0.35f);
+    const Config::INTEGER label_color_value = HTConfig::value<Config::INTEGER>("jump:label_color");
+    const CHyprColor label_color {label_color_value};
+    const CHyprColor background_color {HTConfig::value<Config::INTEGER>("jump:label_background")};
+    const CBox monitor_box {{0, 0}, monitor->m_transformedSize};
+
+    for (size_t i = 0; i < count; i++) {
+        const auto layout_it = overview_layout.find(targets[i]);
+        if (layout_it == overview_layout.end())
+            continue;
+        const CBox& workspace_box = layout_it->second.box;
+        if (workspace_box.intersection(monitor_box).empty())
+            continue;
+
+        // Text rasterization is relatively expensive and these glyphs are immutable for a
+        // given scale/color, so retain one texture per rendered label style.
+        static std::unordered_map<std::string, SP<Render::ITexture>> texture_cache;
+        const std::string texture_key = std::string(1, LABELS[i]) + ":" + std::to_string(font_size)
+            + ":" + std::to_string(label_color_value);
+        auto& texture = texture_cache[texture_key];
+        if (texture == nullptr) {
+            texture = g_pHyprRenderer->renderText(
+                std::string(1, LABELS[i]),
+                label_color,
+                font_size,
+                false,
+                "",
+                0,
+                700
+            );
+        }
+        if (texture == nullptr)
+            continue;
+
+        const Vector2D badge_size = texture->m_size + Vector2D {padding * 2.f, padding};
+        const Vector2D badge_pos = workspace_box.pos() + (workspace_box.size() - badge_size) / 2.f;
+        const CBox badge_box {badge_pos, badge_size};
+
+        CRectPassElement::SRectData badge;
+        badge.box = badge_box;
+        badge.color = background_color;
+        badge.round = std::round(std::min(badge_size.x, badge_size.y) * 0.22f);
+        g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(badge));
+
+        CTexPassElement::SRenderData text;
+        text.tex = texture;
+        text.box = CBox {badge_pos + (badge_size - texture->m_size) / 2.f, texture->m_size};
+        g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(text)));
+    }
+}
+
 const std::string CLEAR_PASS_ELEMENT_NAME = "CClearPassElement";
 
 void HTLayoutBase::post_render() {
@@ -88,6 +190,7 @@ void HTLayoutBase::post_render() {
         first = false;
         return res;
     });
+    render_jump_labels();
     g_pHyprRenderer->m_renderPass.add(makeUnique<HTPassElement>());
     // g_pHyprOpenGL->setDamage(CRegion {CBox {0, 0, INT32_MAX, INT32_MAX}});
 }

--- a/src/layout/layout_base.hpp
+++ b/src/layout/layout_base.hpp
@@ -4,7 +4,9 @@
 #include <hyprland/src/desktop/DesktopTypes.hpp>
 #include <hyprland/src/helpers/AnimatedVariable.hpp>
 #include <hyprutils/math/Box.hpp>
+#include <optional>
 #include <unordered_map>
+#include <vector>
 
 #include "../types.hpp"
 
@@ -70,8 +72,15 @@ class HTLayoutBase {
     // Render the overview
     virtual void render();
 
+    // Workspaces in the same visual order used by the keyboard jump labels.
+    std::vector<WORKSPACEID> jump_targets() const;
+    std::optional<WORKSPACEID> jump_target(size_t index) const;
+
     // Prevent simplification from happening in the plugin, remove all clear pass objects
     void post_render();
+
+    // Draw keyboard jump labels over the workspace previews.
+    void render_jump_labels();
 
     PHLMONITOR get_monitor();
     WORKSPACEID get_ws_id_from_global(Vector2D pos);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -492,6 +492,12 @@ static void on_mouse_button(IPointer::SButtonEvent e, Event::SCallbackInfo& info
     }
 }
 
+static void on_key(IKeyboard::SKeyEvent e, Event::SCallbackInfo& info) {
+    if (ht_manager == nullptr)
+        return;
+    info.cancelled = ht_manager->on_key(e);
+}
+
 static void on_mouse_move(Vector2D c, Event::SCallbackInfo& info) {
     if (ht_manager == nullptr)
         return;
@@ -686,6 +692,7 @@ static void register_callbacks() {
     static auto P1 = Event::bus()->m_events.input.mouse.button.listen(on_mouse_button);
     static auto P2 = Event::bus()->m_events.input.mouse.move.listen(on_mouse_move);
     static auto P3 = Event::bus()->m_events.input.mouse.axis.listen(on_mouse_axis);
+    static auto PKEY = Event::bus()->m_events.input.keyboard.key.listen(on_key);
 
     // TODO: support touch
     static auto P4 = Event::bus()->m_events.input.touch.down.listen([&] (ITouch::SDownEvent e, Event::SCallbackInfo i) { cancel_event(i); } );
@@ -754,6 +761,12 @@ static void init_config() {
 
     addConfigValue(CIntValue, "drag_button", "drag button", BTN_LEFT);
     addConfigValue(CIntValue, "select_button", "select button", BTN_RIGHT);
+
+    // keyboard workspace jump labels
+    addConfigValue(CIntValue, "jump:enabled", "enable keyboard workspace jump labels", 0);
+    addConfigValue(CIntValue, "jump:label_color", "jump label color", 0xFFFFFFFF);
+    addConfigValue(CIntValue, "jump:label_background", "jump label background", 0x000000CC);
+    addConfigValue(CIntValue, "jump:label_size", "jump label font size", 32);
 
     // swipe
     addConfigValue(CIntValue, "gestures:enabled", "enabled", 1);

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -115,6 +115,7 @@ void HTManager::show_cursor_view() {
 void HTManager::reset() {
     swipe_state = HT_SWIPE_NONE;
     swipe_amt = 0.0;
+    jump_pressed_keys.clear();
     views.clear();
 }
 

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <hyprland/src/desktop/DesktopTypes.hpp>
+#include <hyprland/src/devices/IKeyboard.hpp>
 #include <hyprland/src/helpers/AnimatedVariable.hpp>
+#include <unordered_set>
 
 #include "overview.hpp"
 
@@ -29,6 +31,7 @@ class HTManager {
     bool start_window_drag();
     bool end_window_drag();
     bool exit_to_workspace();
+    bool on_key(IKeyboard::SKeyEvent event);
     bool on_mouse_move();
     bool on_mouse_axis(double delta);
 
@@ -40,6 +43,7 @@ class HTManager {
 
     swipe_state_t swipe_state;
     float swipe_amt;
+    std::unordered_set<uint32_t> jump_pressed_keys;
     void swipe_start();
     bool swipe_update(IPointer::SSwipeUpdateEvent e);
     bool swipe_end();

--- a/src/overview.cpp
+++ b/src/overview.cpp
@@ -95,7 +95,7 @@ void HTView::show(bool recalculate) {
     g_pCompositor->scheduleFrameForMonitor(monitor);
 }
 
-void HTView::hide(bool exit_on_mouse) {
+void HTView::hide(bool exit_on_mouse, std::optional<WORKSPACEID> target_workspace) {
     const PHLMONITOR monitor = get_monitor();
     if (monitor == nullptr)
         return;
@@ -103,7 +103,16 @@ void HTView::hide(bool exit_on_mouse) {
     if (active_workspace == nullptr)
         return;
 
-    do_exit_behavior(exit_on_mouse);
+    if (target_workspace.has_value()) {
+        PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByID(*target_workspace);
+        if (workspace == nullptr && *target_workspace != WORKSPACE_INVALID)
+            workspace = g_pCompositor->createNewWorkspace(*target_workspace, monitor->m_id);
+        if (workspace == nullptr)
+            return;
+        monitor->changeWorkspace(workspace);
+    } else {
+        do_exit_behavior(exit_on_mouse);
+    }
 
     active = true;
     closing = true;

--- a/src/overview.hpp
+++ b/src/overview.hpp
@@ -7,6 +7,7 @@
 #include <hyprland/src/macros.hpp>
 #include <hyprutils/math/Box.hpp>
 #include <hyprutils/math/Vector2D.hpp>
+#include <optional>
 
 #include "layout/layout_base.hpp"
 
@@ -32,7 +33,7 @@ class HTView {
     PHLMONITOR get_monitor();
 
     void show(bool recalculate = true);
-    void hide(bool exit_on_mouse);
+    void hide(bool exit_on_mouse, std::optional<WORKSPACEID> target_workspace = std::nullopt);
 
     void move_id(WORKSPACEID ws_id, bool move_window);
     // arg is up, down, left, right;


### PR DESCRIPTION
## Summary

- add an opt-in keyboard jump mode for overview workspaces
- assign labels in spatial order using 1-9, 0, then a-z
- render configurable centered label badges for both grid and linear layouts
- respect the active XKB layout, consume handled key releases, and close directly onto the selected workspace
- document the feature for Lua and legacy Hyprland configuration
- preserve the render-pass element access already used by upstream main for Hyprland v0.55.3 and v0.55.4

## Compatibility

Hyprland changed RenderPass::m_passElements between v0.55.2 and v0.55.3: v0.55.0-v0.55.2 store unique pointers, while v0.55.3-v0.55.4 store values. This branch is based directly on current hyprtasking main and deliberately preserves its value-form access. Older Hyprland releases remain handled by hyprtasking's existing commit-pinning model in hyprpm.toml.

## Testing

- nix build .#hyprtasking --override-input hyprland git+https://github.com/hyprwm/Hyprland?submodules=1&ref=refs/tags/v0.55.4 --no-write-lock-file --no-link -L
- full Hyprland v0.55.4 and hyprtasking plugin compilation and link completed successfully