### PR TITLE
fix: prune build/ from cpp source glob in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,7 +19,7 @@ add_project_arguments(
   ],
   language: 'cpp')
 
-globber = run_command('find', '.', '-name', '*.cpp', check: true)
+globber = run_command('find', '.', '-path', './build', '-prune', '-o', '-name', '*.cpp', '-print', check: true)
 src = globber.stdout().strip().split('\n')
 
 incdir = []


### PR DESCRIPTION
Building against a recent meson (1.12.0+) fails for me with:

```
ninja: error: 'build/meson-private/sanity_check_for_cpp.cpp', needed by 'libhyprtasking.so.p/meson-generated_.._build_meson-private_sanity_check_for_cpp.cpp.o', missing and no known rule to make it
```

Turns out the source glob in meson.build:

```
globber = run_command('find', '.', '-name', '*.cpp', check: true)
```

has no exclusion for the in-source `build/` dir, so it picks up meson's own private sanity-check file (`build/meson-private/sanity_check_for_cpp.cpp`), which gets written before this line runs. Newer meson apparently doesn't leave that file sitting around by the time `meson compile` runs, so ninja chokes on it.

Fix is just pruning `./build` from the find:

```
run_command('find', '.', '-path', './build', '-prune', '-o', '-name', '*.cpp', '-print', check: true)
```

Tested this from a couple of fresh clones against Hyprland 0.56.2 - was hitting the exact error above before, builds and loads fine after (overview grid, bg_color, gaps, border, drag all working).
