### PR TITLE
Keep the overview out of the precomputed blur cache

### DIFF
--- a/src/layout/layout_base.cpp
+++ b/src/layout/layout_base.cpp
@@ -15,6 +15,8 @@
 #include <hyprland/src/render/pass/TexPassElement.hpp>
 #undef private
 
+#include <hyprland/src/output/Monitor.hpp>
+
 #include "../config.hpp"
 #include "../globals.hpp"
 #include "../pass/pass_element.hpp"
@@ -81,6 +83,33 @@ void HTLayoutBase::build_overview_layout(HTViewStage stage) {
 }
 
 void HTLayoutBase::render() {
+    // Keep the overview out of the monitor's precomputed background-blur cache.
+    //
+    // Hyprland queues the precompute-blur pass from inside renderWorkspace
+    // (`if (preBlurQueued(pMonitor)) m_renderPass.add(CPreBlurElement)`), and
+    // preBlurForCurrentMonitor() blurs whatever the main framebuffer holds at that
+    // point. render_workspace_at_box() calls the original renderWorkspace once per
+    // tile, so left alone the cache ends up holding a blurred snapshot of the tiled
+    // grid -- which every surface using decoration:blur:xray (or new_optimizations)
+    // then samples, long after the overview is gone.
+    //
+    // Suppressing the queue for the duration of the overview render leaves the cache
+    // holding the real desktop, so there is nothing to repair on close. If the cache
+    // was already due for a refresh, the flag is restored in post_render() and
+    // Hyprland recomputes it on an ordinary frame, through its normal preRender()
+    // path -- forcing the recompute ourselves instead risks hitting
+    // blurMainFramebuffer()'s "null fb texture (introspection off?!)" path, which
+    // clears the cache to black for a frame.
+    //
+    // The overview's own blur is unaffected: hook_blur_optimizations() already forces
+    // the live blur path while tiles are being rendered scaled.
+    if (const PHLMONITOR monitor = get_monitor()) {
+        saved_blur_fb_dirty = monitor->m_blurFBDirty;
+        saved_blur_fb_should_render = monitor->m_blurFBShouldRender;
+        monitor->m_blurFBDirty = false;
+        monitor->m_blurFBShouldRender = false;
+    }
+
     CClearPassElement::SClearData data;
     data.color = CHyprColor {0};
     g_pHyprRenderer->m_renderPass.add(makeUnique<CClearPassElement>(data));
@@ -194,6 +223,13 @@ void HTLayoutBase::post_render() {
     render_jump_labels();
     g_pHyprRenderer->m_renderPass.add(makeUnique<HTPassElement>());
     // g_pHyprOpenGL->setDamage(CRegion {CBox {0, 0, INT32_MAX, INT32_MAX}});
+
+    // Hand the blur-FB state back exactly as render() found it, so a refresh that
+    // fell due while the overview was open still happens once it closes.
+    if (const PHLMONITOR monitor = get_monitor()) {
+        monitor->m_blurFBDirty = saved_blur_fb_dirty;
+        monitor->m_blurFBShouldRender = saved_blur_fb_should_render;
+    }
 }
 
 PHLMONITOR HTLayoutBase::get_monitor() {

--- a/src/layout/layout_base.hpp
+++ b/src/layout/layout_base.hpp
@@ -21,6 +21,11 @@ class HTLayoutBase {
     // Same as monitor_id of the parent view
     VIEWID view_id;
 
+    // Monitor blur-FB state saved for the duration of an overview render;
+    // see render() / post_render().
+    bool saved_blur_fb_dirty = false;
+    bool saved_blur_fb_should_render = false;
+
   public:
     using CallbackFun = Hyprutils::Animation::CBaseAnimatedVariable::CallbackFun;
 


### PR DESCRIPTION
**Problem**

When blur is enabled (either through decoration:blur:xray or new_optimizations), closing the overview leaves a blurred snapshot of the workspace grid stuck in the desktop background. It doesn't go away until something unrelated triggers a blur cache refresh, like manually switching workspaces, which makes it look like a rendering bug rather than what it actually is.

**Why it happens**

Hyprland queues its precompute blur pass from inside renderWorkspace:

```cpp
// pre window pass
if (preBlurQueued(pMonitor))
    m_renderPass.add(makeUnique<CPreBlurElement>());
```

The problem is that preBlurForCurrentMonitor() just blurs whatever's currently sitting in the main framebuffer. Since render_workspace_at_box() calls renderWorkspace once per tile, this pass ends up firing in the middle of rendering the grid. That means the monitor's m_blurFB gets a blurred copy of the tiled overview baked into it. From then on, anything reading from that cached blur shows the grid, even long after the overview has closed.

**The fix**

The fix suppresses the blur queue for as long as the overview is rendering. HTLayoutBase::render() saves and clears m_blurFBDirty and m_blurFBShouldRender, and post_render() puts them back afterward. Since the cache never gets touched with the overview's contents, there's nothing left to clean up when it closes. And because the flags get restored afterward, any blur refresh that would've happened while the overview was open still happens normally on the next regular frame.

The overview's own blur still works fine, since hook_blur_optimizations() already forces it onto the live blur path while tiles are rendering at a scaled size.

**Approaches that didn't work**

- Damaging the monitor on close: this had no effect, since damage just triggers a redraw, and that redraw pulls from the same cached (and still wrong) blur framebuffer.
- Forcing m_blurFBDirty = true on close: this did clear the artifact, but it forced the recompute to happen outside Hyprland's normal preRender() flow. With introspection off at that point, blurMainFramebuffer() falls back to its "null fb texture" path and clears the cache to black instead, which caused an occasional black flash when closing the overview.

**Testing**

Tested on Hyprland 0.56.2, single monitor, grid layout, with blur:xray = 1 and new_optimizations = 1, wallpaper handled by a layer-shell client (Quickshell). 
